### PR TITLE
flaky network adaptations

### DIFF
--- a/catalystwan/api/templates/models/cisco_bgp_model.py
+++ b/catalystwan/api/templates/models/cisco_bgp_model.py
@@ -183,7 +183,7 @@ class Ipv6Neighbor(FeatureTemplateValidator):
     address: str
     description: Optional[str] = None
     shutdown: Optional[BoolStr] = None
-    remote_as: int = Field(default=None, json_schema_extra={"vmanage_key": "remote-as"})
+    remote_as: int = Field(json_schema_extra={"vmanage_key": "remote-as"})
     keepalive: Optional[int] = Field(default=None, json_schema_extra={"data_path": ["timers"]})
     holdtime: Optional[int] = Field(default=None, json_schema_extra={"data_path": ["timers"]})
     if_name: Optional[str] = Field(

--- a/catalystwan/api/templates/models/cisco_snmp_model.py
+++ b/catalystwan/api/templates/models/cisco_snmp_model.py
@@ -66,9 +66,9 @@ class Target(FeatureTemplateValidator):
     vpn_id: int = Field(json_schema_extra={"vmanage_key": "vpn-id"})
     ip: str
     port: int
-    community_name: str = Field(default=None, json_schema_extra={"vmanage_key": "community-name"})
+    community_name: Optional[str] = Field(default=None, json_schema_extra={"vmanage_key": "community-name"})
     user: Optional[str] = None
-    source_interface: str = Field(default=None, json_schema_extra={"vmanage_key": "source-interface"})
+    source_interface: Optional[str] = Field(default=None, json_schema_extra={"vmanage_key": "source-interface"})
     model_config = ConfigDict(populate_by_name=True)
 
 

--- a/catalystwan/api/templates/models/cisco_system.py
+++ b/catalystwan/api/templates/models/cisco_system.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from pathlib import Path
-from typing import ClassVar, List, Optional
+from typing import ClassVar, List, Optional, Union
 
 from pydantic import ConfigDict, Field
 
@@ -151,7 +151,9 @@ class CiscoSystemModel(FeatureTemplate):
         default=DeviceVariable(name="system_system_ip"), json_schema_extra={"vmanage_key": "system-ip"}
     )
     overlay_id: Optional[int] = Field(default=None, json_schema_extra={"vmanage_key": "overlay-id"})
-    site_id: int = Field(default=DeviceVariable(name="system_site_id"), json_schema_extra={"vmanage_key": "site-id"})
+    site_id: Union[int, DeviceVariable] = Field(
+        default=DeviceVariable(name="system_site_id"), json_schema_extra={"vmanage_key": "site-id"}
+    )
     site_type: Optional[List[SiteType]] = Field(default=None, json_schema_extra={"vmanage_key": "site-type"})
     port_offset: Optional[int] = Field(default=None, json_schema_extra={"vmanage_key": "port-offset"})
     port_hop: Optional[BoolStr] = Field(default=None, json_schema_extra={"vmanage_key": "port-hop"})

--- a/catalystwan/api/templates/models/cisco_vpn_model.py
+++ b/catalystwan/api/templates/models/cisco_vpn_model.py
@@ -229,7 +229,7 @@ class Overload(str, Enum):
 class Natpool(FeatureTemplateValidator):
     name: int
     prefix_length: Optional[int] = Field(default=None, json_schema_extra={"vmanage_key": "prefix-length"})
-    range_start: str = Field(default=None, json_schema_extra={"vmanage_key": "range-start"})
+    range_start: str = Field(json_schema_extra={"vmanage_key": "range-start"})
     range_end: Optional[str] = Field(default=None, json_schema_extra={"vmanage_key": "range-end"})
     overload: Overload = Overload.TRUE
     direction: Direction

--- a/catalystwan/api/templates/models/system_vsmart_model.py
+++ b/catalystwan/api/templates/models/system_vsmart_model.py
@@ -37,7 +37,7 @@ class SystemVsmart(FeatureTemplate):
     device_groups: Optional[str] = Field(default=None, json_schema_extra={"vmanage_key": "device-groups"})
     longitude: Optional[int] = Field(default=None, ge=-180, le=180)
     latitude: Optional[int] = Field(default=None, ge=-90, le=90)
-    system_tunnel_mtu: Optional[str] = Field(default=1024, json_schema_extra={"vmanage_key": "system-tunnel-mtu"})
+    system_tunnel_mtu: Optional[int] = Field(default=1024, json_schema_extra={"vmanage_key": "system-tunnel-mtu"})
     location: Optional[str] = None
     host_name: Optional[str] = Field(default=None, json_schema_extra={"vmanage_key": "host-name"})
 

--- a/catalystwan/endpoints/configuration/software_actions.py
+++ b/catalystwan/endpoints/configuration/software_actions.py
@@ -100,8 +100,8 @@ class RemoteServerInfo(BaseModel):
 class SoftwareRemoteServer(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    filename: str = Field(default=None, serialization_alias="fileName", validation_alias="fileName")
-    remote_server_id: str = Field(default=None, serialization_alias="remoteServerId", validation_alias="remoteServerId")
+    filename: str = Field(serialization_alias="fileName", validation_alias="fileName")
+    remote_server_id: str = Field(serialization_alias="remoteServerId", validation_alias="remoteServerId")
     smu_defect_id: Optional[str] = Field(
         default=None, serialization_alias="smuDefectId", validation_alias="smuDefectId"
     )
@@ -158,7 +158,9 @@ class SoftwareImageDetails(BaseModel):
     vnf_properties_json: Optional[str] = Field(
         default=None, serialization_alias="vnfPropertiesJson", validation_alias="vnfPropertiesJson"
     )
-    remote_server_id: str = Field(default=None, serialization_alias="remoteServerId", validation_alias="remoteServerId")
+    remote_server_id: Optional[str] = Field(
+        default=None, serialization_alias="remoteServerId", validation_alias="remoteServerId"
+    )
 
 
 class ConfigurationSoftwareActions(APIEndpoints):

--- a/catalystwan/endpoints/configuration_dashboard_status.py
+++ b/catalystwan/endpoints/configuration_dashboard_status.py
@@ -61,7 +61,7 @@ class Validation(BaseModel):
     device_id: Optional[str] = Field(default=None, serialization_alias="deviceID", validation_alias="deviceID")
     uuid: Optional[str] = Field(default=None, serialization_alias="uuid", validation_alias="uuid")
     rid: Optional[int] = Field(default=None, serialization_alias="@rid", validation_alias="@rid")
-    status_id: str = Field(default=None, serialization_alias="statusId", validation_alias="statusId")
+    status_id: str = Field(serialization_alias="statusId", validation_alias="statusId")
     process_id: Optional[str] = Field(default=None, serialization_alias="processId", validation_alias="processId")
     action_config: Optional[Union[str, Dict]] = Field(
         default=None, serialization_alias="actionConfig", validation_alias="actionConfig"
@@ -74,7 +74,7 @@ class Validation(BaseModel):
     request_status: Optional[str] = Field(
         default=None, serialization_alias="requestStatus", validation_alias="requestStatus"
     )
-    status: OperationStatus = Field(default=None, serialization_alias="status", validation_alias="status")
+    status: OperationStatus = Field(serialization_alias="status", validation_alias="status")
     order: Optional[int] = Field(default=None, serialization_alias="order", validation_alias="order")
 
 

--- a/catalystwan/models/configuration/feature_profile/common.py
+++ b/catalystwan/models/configuration/feature_profile/common.py
@@ -221,7 +221,7 @@ class IPv4Prefix(BaseModel):
 class WANIPv4StaticRoute(BaseModel):
     prefix: IPv4Prefix = Field()
     gateway: Global[Literal["nextHop", "null0", "dhcp"]] = Field(default=Global(value="nextHop"), alias="gateway")
-    next_hops: Optional[List[NextHop]] = Field(default_factory=list, alias="nextHop")
+    next_hops: Optional[List[NextHop]] = Field(default=None, serialization_alias="nextHop", validation_alias="nextHop")
     distance: Optional[Global[int]] = Field(default=None, alias="distance")
 
     def set_to_next_hop(

--- a/catalystwan/models/configuration/feature_profile/sdwan/management/vpn.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/management/vpn.py
@@ -17,10 +17,10 @@ from catalystwan.models.configuration.feature_profile.common import (
 class ManagementVPN(BaseModel):
     # TODO (mlembke): vpn_id can't have other value, it needs to be constant. How to do that?
     vpn_id: Default[int] = Field(default=Default(value=512), frozen=True, alias="vpnId")
-    ipv4_routes: Optional[List[WANIPv4StaticRoute]] = Field(default=[], alias="ipv4Route")
-    ipv6_routes: Optional[List[WANIPv6StaticRoute]] = Field(default=[], alias="ipv6Route")
+    ipv4_routes: Optional[List[WANIPv4StaticRoute]] = Field(default=None, alias="ipv4Route")
+    ipv6_routes: Optional[List[WANIPv6StaticRoute]] = Field(default=None, alias="ipv6Route")
     dns_ipv4: Optional[DNSIPv4] = Field(default=None, alias="dnsIpv4")
     dns_ipv6: Optional[DNSIPv6] = Field(default=None, alias="dnsIpv6")
-    new_host_mapping: Optional[List[HostMapping]] = Field(default=[], alias="newHostMapping")
+    new_host_mapping: Optional[List[HostMapping]] = Field(default=None, alias="newHostMapping")
     # TODO (mlembke): add interfaces
     interface: Optional[Any] = Field(default=None)

--- a/catalystwan/models/configuration/feature_profile/sdwan/service/bgp.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/bgp.py
@@ -157,7 +157,7 @@ class BgpIPv4Neighbor(BaseModel):
     description: Optional[Union[Global[str], Variable, Default[None]]] = None
     shutdown: Optional[Union[Global[bool], Variable, Default[bool]]] = Default[bool](value=False)
     remote_as: Union[Global[int], Variable] = Field(serialization_alias="remoteAs", validation_alias="remoteAs")
-    local_as: Union[Global[int], Variable] = Field(
+    local_as: Optional[Union[Global[str], Global[int], Variable, Default[None]]] = Field(
         serialization_alias="localAs", validation_alias="localAs", default=None
     )
     keepalive: Optional[Union[Global[int], Variable, Default[int]]] = Default[int](value=60)
@@ -199,7 +199,7 @@ class BgpIPv6Neighbor(BaseModel):
     description: Optional[Union[Global[str], Variable, Default[None]]] = None
     shutdown: Optional[Union[Global[bool], Variable, Default[bool]]] = Default[bool](value=False)
     remote_as: Union[Global[int], Variable] = Field(serialization_alias="remoteAs", validation_alias="remoteAs")
-    local_as: Union[Global[int], Variable] = Field(
+    local_as: Optional[Union[Global[str], Global[int], Variable, Default[None]]] = Field(
         serialization_alias="localAs", validation_alias="localAs", default=None
     )
     keepalive: Optional[Union[Global[int], Variable, Default[int]]] = Default[int](value=60)

--- a/catalystwan/request.py
+++ b/catalystwan/request.py
@@ -1,0 +1,35 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
+from logging import getLogger
+from typing import Callable, Tuple, Type, TypeVar
+
+from requests import delete, get, head, options, patch, post, put, request
+from requests.exceptions import ConnectionError, Timeout
+from typing_extensions import Concatenate, ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+logger = getLogger(__name__)
+
+
+def retry(function: Callable[P, T], catch: Tuple[Type[Exception], ...]) -> Callable[Concatenate[int, P], T]:
+    def decorator(retries: int, *args: P.args, **kwargs: P.kwargs) -> T:
+        for _ in range(retries):
+            try:
+                return function(*args, **kwargs)
+            except catch as e:
+                logger.warning(f"Retrying: {e}")
+        return function(*args, **kwargs)
+
+    return decorator
+
+
+# retry decorators for request methods, retries count added as first positional argument
+catch = (ConnectionError, Timeout)
+retry_request = retry(request, catch)
+retry_get = retry(get, catch)
+retry_options = retry(options, catch)
+retry_head = retry(head, catch)
+retry_post = retry(post, catch)
+retry_put = retry(put, catch)
+retry_patch = retry(patch, catch)
+retry_delete = retry(delete, catch)

--- a/catalystwan/tests/test_vmanage_auth.py
+++ b/catalystwan/tests/test_vmanage_auth.py
@@ -85,10 +85,12 @@ class TestvManageAuth(TestCase):
 
         # Assert
         mock_post.assert_called_with(
+            vmanage_auth.request_retries,
             url="https://1.1.1.1:1111/j_security_check",
             data=security_payload,
             verify=False,
             headers={"Content-Type": "application/x-www-form-urlencoded", "User-Agent": USER_AGENT},
+            timeout=vmanage_auth.request_timeout,
         )
 
     @mock.patch("catalystwan.vmanage_auth.post", side_effect=mock_request_j_security_check)
@@ -99,16 +101,19 @@ class TestvManageAuth(TestCase):
             "j_username": username,
             "j_password": self.password,
         }
+        vmanage_auth = vManageAuth(username, self.password)
         # Act
         with self.assertRaises(UnauthorizedAccessError):
-            vManageAuth(username, self.password).get_jsessionid()
+            vmanage_auth.get_jsessionid()
 
         # Assert
         mock_post.assert_called_with(
+            vmanage_auth.request_retries,
             url="/j_security_check",
             data=security_payload,
             verify=False,
             headers={"Content-Type": "application/x-www-form-urlencoded", "User-Agent": USER_AGENT},
+            timeout=vmanage_auth.request_timeout,
         )
 
     @mock.patch("catalystwan.vmanage_auth.get", side_effect=mock_valid_token)
@@ -128,10 +133,12 @@ class TestvManageAuth(TestCase):
         self.assertEqual(token, "valid-token")
 
         mock_get.assert_called_with(
+            vmanage_auth.request_retries,
             url=valid_url,
             verify=False,
             headers={"Content-Type": "application/json", "User-Agent": USER_AGENT},
             cookies=cookies,
+            timeout=vmanage_auth.request_timeout,
         )
 
     @mock.patch("catalystwan.vmanage_auth.get", side_effect=mock_invalid_token_status)


### PR DESCRIPTION
# Pull Request summary:
Mitigate SDK hanging during http requests when network is unstable.

# Description of changes:
Add default request timeouts and retries.
- set default `request_timeout` to `10s` in `ManagerSession`
- mount `HTTPAdapter` with sensible retry settings by default in `ManagerSession`
- set default `request_timeout` to `10s` in `vManageAuth`
- set default `request_retries` to `1` in `vManageAuth`

Fix old mypy violations detected incidentally (cherry-picked from already fixed dev branch [commit](https://github.com/cisco-en-programmability/catalystwan-sdk/pull/6/commits/5d3a0afdcfd767155be65fc00a24412b74293fff))

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
