### PR TITLE
interface ethernet parcel improvement example

### DIFF
--- a/catalystwan/api/configuration_groups/parcel.py
+++ b/catalystwan/api/configuration_groups/parcel.py
@@ -197,3 +197,10 @@ def as_default(value: Any, generic_alias: Any = None):
     raise TypeError(
         f"Inappropriate type origin: {generic_alias} {get_origin(generic_alias)} for argument generic_alias"
     )
+
+
+def as_optional_global_or_variable(value: Any, generic_alias: Any = None):
+    if isinstance(value, str) and value.startswith("{{") and value.endswith("}}"):
+        return as_variable(value)
+    else:
+        return as_optional_global(value, generic_alias)

--- a/catalystwan/models/configuration/feature_profile/common.py
+++ b/catalystwan/models/configuration/feature_profile/common.py
@@ -8,7 +8,15 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Self
 
-from catalystwan.api.configuration_groups.parcel import Default, Global, Variable, as_default, as_global
+from catalystwan.api.configuration_groups.parcel import (
+    Default,
+    Global,
+    Variable,
+    as_default,
+    as_global,
+    as_optional_global,
+    as_optional_global_or_variable,
+)
 from catalystwan.models.common import (
     CableLengthLongValue,
     CableLengthShortValue,
@@ -484,6 +492,18 @@ class Encapsulation(BaseModel):
     encap: Optional[Global[EncapType]] = Field(default=None)
     preference: Optional[Union[Global[int], Variable, Default[None]]] = Field(default=None)
     weight: Optional[Union[Global[int], Variable, Default[int]]] = Field(default=None)
+
+    @staticmethod
+    def from_params(
+        encap: Optional[EncapType] = None,
+        preference: Union[None, int, str] = None,
+        weight: Union[None, int, str] = None,
+    ) -> "Encapsulation":
+        return Encapsulation(
+            encap=as_optional_global(encap, EncapType),
+            preference=as_optional_global_or_variable(preference),
+            weight=as_optional_global_or_variable(weight),
+        )
 
 
 class AllowService(BaseModel):

--- a/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/ethernet.py
@@ -5,7 +5,15 @@ from typing import List, Literal, Optional, Union
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
 
 from catalystwan.api.configuration_groups.parcel import Default, Global, Variable, _ParcelBase, as_default
-from catalystwan.models.common import CarrierType, EthernetDuplexMode, MediaType, Speed, TLOCColor, TunnelMode
+from catalystwan.models.common import (
+    CarrierType,
+    EncapType,
+    EthernetDuplexMode,
+    MediaType,
+    Speed,
+    TLOCColor,
+    TunnelMode,
+)
 from catalystwan.models.configuration.feature_profile.common import (
     AclQos,
     AllowService,
@@ -196,7 +204,7 @@ class InterfaceEthernetParcel(_ParcelBase):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
     type_: Literal["wan/vpn/interface/ethernet"] = Field(default="wan/vpn/interface/ethernet", exclude=True)
     encapsulation: List[Encapsulation] = Field(
-        validation_alias=AliasPath("data", "encapsulation"), description="Encapsulation for TLOC"
+        default_factory=list, validation_alias=AliasPath("data", "encapsulation"), description="Encapsulation for TLOC"
     )
     interface_name: Union[Variable, Global[str]] = Field(validation_alias=AliasPath("data", "interfaceName"))
     interface_ip_address: Union[InterfaceDynamicIPv4Address, InterfaceStaticIPv4Address] = Field(
@@ -263,3 +271,11 @@ class InterfaceEthernetParcel(_ParcelBase):
     tunnel: Optional[Tunnel] = Field(
         default=None, validation_alias=AliasPath("data", "tunnel"), description="Tunnel Interface Attributes"
     )
+
+    def add_encapsulation(
+        self,
+        encap: Optional[EncapType] = None,
+        preference: Union[None, int, str] = None,
+        weight: Union[None, int, str] = None,
+    ) -> None:
+        self.encapsulation.append(Encapsulation.from_params(encap, preference, weight))


### PR DESCRIPTION
```python
from catalystwan.api.configuration_groups.parcel import Global, Variable, as_global
from catalystwan.models.configuration.feature_profile.common import Encapsulation, EncapType
from catalystwan.models.configuration.feature_profile.sdwan.transport.wan.interface.ethernet import InterfaceEthernetParcel

interface_name_1 = as_global("GigabitEthernet2")            # as_global is not type-safe and will cause type checkers to protest
interface_name_2 = Global[str](value="GigabitEthernet2")    # explicit type-safe instatiation

interface_parcel = InterfaceEthernetParcel(
    parcel_name="SDK_VPN0_Interface_mpls_Parcel",
    interface_name=interface_name_1,
)

# no optionals
interface_parcel.add_encapsulation("ipsec")
# globals
interface_parcel.add_encapsulation("ipsec", 100, 1)
# vars
interface_parcel.add_encapsulation("gre", "{{preferenceVar}}", "{{weightVar}}")

# without helpers (type-safe)
interface_parcel.encapsulation.append(
    Encapsulation(
        encap=Global[EncapType](value="ipsec"),
        preference=Global[int](value=200),
        weight=Variable(value="{{weightVar2}}")
    )
)

print(interface_parcel.model_dump_json(by_alias=True, exclude_none=True, indent=4))
```

```json
{
    "name": "SDK_VPN0_Interface_mpls_Parcel",
    "data": {
        "encapsulation": [
            {
                "encap": {
                    "optionType": "global",
                    "value": "ipsec"
                }
            },
            {
                "encap": {
                    "optionType": "global",
                    "value": "ipsec"
                },
                "preference": {
                    "optionType": "global",
                    "value": 100
                },
                "weight": {
                    "optionType": "global",
                    "value": 1
                }
            },
            {
                "encap": {
                    "optionType": "global",
                    "value": "gre"
                },
                "preference": {
                    "optionType": "variable",
                    "value": "{{preferenceVar}}"
                },
                "weight": {
                    "optionType": "variable",
                    "value": "{{weightVar}}"
                }
            },
            {
                "encap": {
                    "optionType": "global",
                    "value": "ipsec"
                },
                "preference": {
                    "optionType": "global",
                    "value": 200
                },
                "weight": {
                    "optionType": "variable",
                    "value": "{{weightVar2}}"
                }
            }
        ],
        "interfaceName": {
            "optionType": "global",
            "value": "GigabitEthernet2"
        },
        "intfIpAddress": {
            "static": {
                "staticIpV4AddressPrimary": {
                    "ipAddress": {
                        "optionType": "default"
                    },
                    "subnetMask": {
                        "optionType": "default"
                    }
                }
            }
        },
        "nat": {
            "optionType": "default",
            "value": false
        },
        "shutdown": {
            "optionType": "default",
            "value": true
        },
        "tunnelInterface": {
            "optionType": "default",
            "value": false
        }
    }
}
```
