### PR TITLE
dev: get template should pass parameters as key value

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -1,6 +1,6 @@
 **THIS FILE WAS AUTO-GENERATED DO NOT EDIT**
 
-Generated for: catalystwan-0.40.0.dev7
+Generated for: catalystwan-0.40.0.dev9
 
 All URIs are relative to */dataservice*
 HTTP request | Supported Versions | Method | Payload Type | Return Type | Tenancy Mode

--- a/catalystwan/api/template_api.py
+++ b/catalystwan/api/template_api.py
@@ -115,7 +115,9 @@ class TemplatesAPI:
         self, feature: DeviceTemplateFeature = DeviceTemplateFeature.ALL
     ) -> DataSequence[DeviceTemplateInformation]:
         """In a multitenant vManage system, this API is only available in the Provider view."""
-        return self.session.endpoints.configuration_template_master.get_device_template_list(params=feature.value)
+        return self.session.endpoints.configuration_template_master.get_device_template_list(
+            params={"feature": feature.value}
+        )
 
     def attach(self, name: str, device: Device, timeout_seconds: int = 300, **kwargs):
         template_info = self.get(DeviceTemplate).filter(name=name).single_or_default()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.40.0dev8"
+version = "0.40.0dev9"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
This PR cherry-picks get template changes from main

# Description of changes:
During GET template, feature parameter is passed as a {"feature":feature} instead of just feature

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
