### PR TITLE
Dev: add get_device_template_attached_devices_variables api

### DIFF
--- a/catalystwan/api/template_api.py
+++ b/catalystwan/api/template_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Type, overload
+from typing import TYPE_CHECKING, Any, List, Optional, Type, overload
 
 from ciscoconfparse import CiscoConfParse  # type: ignore
 from typing_extensions import deprecated
@@ -13,8 +13,10 @@ from typing_extensions import deprecated
 from catalystwan.api.task_status_api import Task
 from catalystwan.api.templates.cli_template import CLITemplate
 from catalystwan.api.templates.device_template.device_template import (
+    AttachedDeviceValues,
     DeviceSpecificValue,
     DeviceTemplate,
+    DeviceTemplateConfigAttached,
     GeneralTemplate,
 )
 from catalystwan.api.templates.feature_template import FeatureTemplate
@@ -729,3 +731,55 @@ class TemplatesAPI:
         endpoint = f"/dataservice/template/device/object/{template_id}"
         response = self.session.get(endpoint)
         return DeviceTemplate(**response.json())
+
+
+def get_device_template_attached_devices_variables(self, template_id: str) -> List[AttachedDeviceValues]:
+    """
+    Fetches and processes attached device variables for a given device template.
+
+    Args:
+        template_id (str): The ID of the device template.
+
+    Returns:
+        List[AttachedDeviceValues]: A list of AttachedDeviceValues objects containing device variables.
+    """
+    # Fetch attached devices for the template
+    attached_devices_endpoint = f"/dataservice/template/device/config/attached/{template_id}"
+    response = self.session.get(attached_devices_endpoint)
+
+    # Check if the response contains data
+    attached_devices = response.json().get("data", [])
+    if not attached_devices:
+        logger.debug(f"Device template ({template_id}) has no attached devices.")
+        return []
+
+    # Extract UUIDs of attached devices
+    devices = [DeviceTemplateConfigAttached(**ad) for ad in attached_devices]
+    devices_uuids = [d.uuid for d in devices if d.uuid]
+
+    # Prepare payload for fetching device variables
+    payload = {"templateId": template_id, "deviceIds": devices_uuids, "isEdited": False, "isMasterEdited": False}
+
+    # Fetch device variables
+    variables_endpoint = "dataservice/template/device/config/input/"
+    response = self.session.post(variables_endpoint, json=payload)
+    response_data = response.json().get("data", [])
+
+    # Process and map device variables to AttachedDeviceValues
+    result = []
+    for entry in response_data:
+        try:
+            # Create AttachedDeviceValues object
+            adv = AttachedDeviceValues(
+                csv_device_ip=entry.pop("csv-deviceIP"),
+                csv_device_id=entry.pop("csv-deviceId"),
+                csv_host_name=entry.pop("csv-host-name"),
+                csv_status=entry.pop("csv-status"),
+                values=entry,  # Include remaining fields in the `values` attribute
+            )
+            result.append(adv)
+        except KeyError as e:
+            logger.warning(f"Missing expected key in device variables entry: {e}")
+            continue
+
+    return result

--- a/catalystwan/api/templates/device_template/device_template.py
+++ b/catalystwan/api/templates/device_template/device_template.py
@@ -141,3 +141,34 @@ class DeviceTemplate(BaseModel):
 
 class DeviceSpecificValue(BaseModel):
     property: str
+
+
+class DeviceTemplateConfigAttached(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
+    host_name: Optional[str] = Field(None, serialization_alias="host-name", validation_alias="host-name")
+    device_ip: Optional[str] = Field(None, serialization_alias="deviceIP", validation_alias="deviceIP")
+    local_system_ip: Optional[str] = Field(
+        None, serialization_alias="local-system-ip", validation_alias="local-system-ip"
+    )
+    site_id: Optional[str] = Field(None, serialization_alias="site-id", validation_alias="site-id")
+    device_groups: Optional[List[str]] = Field(
+        None, serialization_alias="device-groups", validation_alias="device-groups"
+    )
+    uuid: Optional[str] = Field(None, serialization_alias="uuid", validation_alias="uuid")
+    personality: Optional[str] = Field(None, serialization_alias="personality", validation_alias="personality")
+    config_cloudx_mode: Optional[str] = Field(
+        None, serialization_alias="configCloudxMode", validation_alias="configCloudxMode"
+    )
+
+
+class AttachedDeviceValues(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
+    csv_device_ip: Optional[str] = Field(
+        None,
+        validation_alias="csv-deviceIP",  # Explicit validation alias
+        serialization_alias="csv-deviceIP",  # Explicit serialization alias
+    )
+    csv_device_id: Optional[str] = Field(None, validation_alias="csv-deviceId", serialization_alias="csv-deviceId")
+    csv_host_name: Optional[str] = Field(None, validation_alias="csv-host-name", serialization_alias="csv-host-name")
+    csv_status: Optional[str] = Field(None, validation_alias="csv-status", serialization_alias="csv-status")
+    values: dict

--- a/catalystwan/api/templates/device_template/device_template.py
+++ b/catalystwan/api/templates/device_template/device_template.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -161,14 +161,21 @@ class DeviceTemplateConfigAttached(BaseModel):
     )
 
 
-class AttachedDeviceValues(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
-    csv_device_ip: Optional[str] = Field(
-        None,
-        validation_alias="csv-deviceIP",  # Explicit validation alias
-        serialization_alias="csv-deviceIP",  # Explicit serialization alias
-    )
-    csv_device_id: Optional[str] = Field(None, validation_alias="csv-deviceId", serialization_alias="csv-deviceId")
-    csv_host_name: Optional[str] = Field(None, validation_alias="csv-host-name", serialization_alias="csv-host-name")
-    csv_status: Optional[str] = Field(None, validation_alias="csv-status", serialization_alias="csv-status")
-    values: dict
+class CreateDeviceInputPayload(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    template_id: str = Field(serialization_alias="templateId", validation_alias="templateId")
+    device_ids: List[str] = Field(serialization_alias="deviceIds", validation_alias="deviceIds")
+    is_edited: bool = Field(serialization_alias="isEdited", validation_alias="isEdited")
+    is_master_edited: bool = Field(serialization_alias="isMasterEdited", validation_alias="isMasterEdited")
+
+
+class DeviceInputValues(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    csv_device_ip: str = Field(validation_alias="csv-deviceIP", serialization_alias="csv-deviceIP")
+    csv_device_id: str = Field(validation_alias="csv-deviceId", serialization_alias="csv-deviceId")
+    csv_host_name: str = Field(validation_alias="csv-host-name", serialization_alias="csv-host-name")
+    csv_status: str = Field(validation_alias="csv-status", serialization_alias="csv-status")
+
+    @property
+    def values(self) -> Dict[str, Any]:
+        return self.__pydantic_extra__ or dict()

--- a/catalystwan/endpoints/configuration_device_template.py
+++ b/catalystwan/endpoints/configuration_device_template.py
@@ -5,7 +5,11 @@ from typing import Dict
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from catalystwan.api.templates.device_template.device_template import DeviceTemplateConfigAttached
+from catalystwan.api.templates.device_template.device_template import (
+    CreateDeviceInputPayload,
+    DeviceInputValues,
+    DeviceTemplateConfigAttached,
+)
 from catalystwan.endpoints import APIEndpoints, get, post, view
 from catalystwan.typed_list import DataSequence
 from catalystwan.utils.session_type import ProviderView
@@ -28,4 +32,8 @@ class ConfigurationDeviceTemplate(APIEndpoints):
 
     @get("/template/device/config/attached/{template_id}", resp_json_key="data")
     def get_device_config_attached(self, template_id: str) -> DataSequence[DeviceTemplateConfigAttached]:
+        ...
+
+    @post("/template/device/config/input/", resp_json_key="data")
+    def create_device_input(self, payload: CreateDeviceInputPayload) -> DataSequence[DeviceInputValues]:
         ...

--- a/catalystwan/endpoints/configuration_device_template.py
+++ b/catalystwan/endpoints/configuration_device_template.py
@@ -5,7 +5,9 @@ from typing import Dict
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from catalystwan.endpoints import APIEndpoints, post, view
+from catalystwan.api.templates.device_template.device_template import DeviceTemplateConfigAttached
+from catalystwan.endpoints import APIEndpoints, get, post, view
+from catalystwan.typed_list import DataSequence
 from catalystwan.utils.session_type import ProviderView
 
 
@@ -22,4 +24,8 @@ class ConfigurationDeviceTemplate(APIEndpoints):
     @view({ProviderView})
     @post("/template/device/config/config/")
     def get_device_configuration_preview(self, payload: FeatureToCLIPayload) -> str:
+        ...
+
+    @get("/template/device/config/attached/{template_id}", resp_json_key="data")
+    def get_device_config_attached(self, template_id: str) -> DataSequence[DeviceTemplateConfigAttached]:
         ...


### PR DESCRIPTION
# Pull Request summary:
This PR introduces the `get_device_template_attached_devices_variables` function. The function now fetches and processes attached device variables for a given device template.

Example Usage
```
variables = session.api.templates.get_device_template_attached_devices_variables("template-123")
for var in variables:
    print(var.csv_device_ip, var.csv_host_name, var.values)
```

# Description of changes:
[Add more in depth analysis of what changed, provide logs, examples of usage]

# Checklist:
- [X] Make sure to run pre-commit before committing changes
- [X] Make sure all checks have passed
- [X] PR description is clear and comprehensive
- [X] Mentioned the issue that this PR solves (if applicable)
- [X] Make sure you test the changes
