### PR TITLE
dev: multiple model fixes

### DIFF
--- a/catalystwan/integration_tests/profile_builder/test_pb_uc_voice.py
+++ b/catalystwan/integration_tests/profile_builder/test_pb_uc_voice.py
@@ -60,6 +60,12 @@ class TestUcVoiceFeatureProfileBuilder(TestCaseBase):
             translation_profile_settings=[],
         )
 
+        self.translation_profile2 = TranslationProfileParcel(
+            parcel_name="TranslationProfile2",
+            parcel_description="TranslationProfileDescription",
+            translation_profile_settings=[],
+        )
+
         self.translation_rule_calling = TranslationRuleParcel(
             parcel_name="TranslationRuleCalling",
             parcel_description="Description",
@@ -110,6 +116,19 @@ class TestUcVoiceFeatureProfileBuilder(TestCaseBase):
     def test_build_profile_with_translation_profile_and_rules(self):
         self.builder.add_translation_profile(
             self.translation_profile, self.translation_rule_calling, self.translation_rule_called
+        )
+
+        report = self.builder.build()
+
+        assert len(report.failed_parcels) == 0, "Failed to build feature profile with translation profile and rules."
+
+    def test_build_profile_with_translation_profile_and_same_rules_references(self):
+        self.builder.add_translation_profile(
+            self.translation_profile, self.translation_rule_calling, self.translation_rule_called
+        )
+
+        self.builder.add_translation_profile(
+            self.translation_profile2, self.translation_rule_calling, self.translation_rule_called
         )
 
         report = self.builder.build()

--- a/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/ipsec.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/ipsec.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 from __future__ import annotations
 
+from ipaddress import IPv4Address
 from typing import Literal, Optional, Union
 
 from pydantic import AliasPath, ConfigDict, Field
@@ -52,7 +53,7 @@ class InterfaceIpsecParcel(_ParcelBase):
     ike_rekey_interval: Union[Variable, Default[int], Global[int]] = Field(
         default=as_default(14400), validation_alias=AliasPath("data", "ikeRekeyInterval")
     )
-    ike_remote_id: Union[Variable, Global[str], Default[None]] = Field(
+    ike_remote_id: Union[Variable, Global[str], Default[None], Global[IPv4Address]] = Field(
         default=Default[None](value=None), validation_alias=AliasPath("data", "ikeRemoteId")
     )
     ike_version: Union[Global[int], Default[int]] = Field(

--- a/catalystwan/models/configuration/feature_profile/sdwan/uc_voice/media_profile.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/uc_voice/media_profile.py
@@ -3,7 +3,7 @@ from typing import List, Literal, Optional, Union
 
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
 
-from catalystwan.api.configuration_groups.parcel import Global, Variable, _ParcelBase, Default
+from catalystwan.api.configuration_groups.parcel import Default, Global, Variable, _ParcelBase
 from catalystwan.models.common import MpDtmf, MpVoiceCodec
 
 
@@ -19,5 +19,7 @@ class MediaProfileParcel(_ParcelBase):
     model_config = ConfigDict(populate_by_name=True)
     type_: Literal["media-profile"] = Field(default="media-profile", exclude=True)
     codec: Global[List[MpVoiceCodec]] = Field(validation_alias=AliasPath("data", "codec"))
-    dtmf: Union[Variable, Global[List[MpDtmf]], Default[List[MpDtmf]]] = Field(validation_alias=AliasPath("data", "dtmf"))
+    dtmf: Union[Variable, Global[List[MpDtmf]], Default[List[MpDtmf]]] = Field(
+        validation_alias=AliasPath("data", "dtmf")
+    )
     media_profile_number: Union[Variable, Global[int]] = Field(validation_alias=AliasPath("data", "mediaProfileNumber"))

--- a/catalystwan/models/configuration/feature_profile/sdwan/uc_voice/media_profile.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/uc_voice/media_profile.py
@@ -19,5 +19,5 @@ class MediaProfileParcel(_ParcelBase):
     model_config = ConfigDict(populate_by_name=True)
     type_: Literal["media-profile"] = Field(default="media-profile", exclude=True)
     codec: Global[List[MpVoiceCodec]] = Field(validation_alias=AliasPath("data", "codec"))
-    dtmf: Union[Variable, Global[MpDtmf]] = Field(validation_alias=AliasPath("data", "dtmf"))
+    dtmf: Union[Variable, Global[List[MpDtmf]]] = Field(validation_alias=AliasPath("data", "dtmf"))
     media_profile_number: Union[Variable, Global[int]] = Field(validation_alias=AliasPath("data", "mediaProfileNumber"))

--- a/catalystwan/models/configuration/feature_profile/sdwan/uc_voice/media_profile.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/uc_voice/media_profile.py
@@ -3,7 +3,7 @@ from typing import List, Literal, Optional, Union
 
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
 
-from catalystwan.api.configuration_groups.parcel import Global, Variable, _ParcelBase
+from catalystwan.api.configuration_groups.parcel import Global, Variable, _ParcelBase, Default
 from catalystwan.models.common import MpDtmf, MpVoiceCodec
 
 
@@ -19,5 +19,5 @@ class MediaProfileParcel(_ParcelBase):
     model_config = ConfigDict(populate_by_name=True)
     type_: Literal["media-profile"] = Field(default="media-profile", exclude=True)
     codec: Global[List[MpVoiceCodec]] = Field(validation_alias=AliasPath("data", "codec"))
-    dtmf: Union[Variable, Global[List[MpDtmf]]] = Field(validation_alias=AliasPath("data", "dtmf"))
+    dtmf: Union[Variable, Global[List[MpDtmf]], Default[List[MpDtmf]]] = Field(validation_alias=AliasPath("data", "dtmf"))
     media_profile_number: Union[Variable, Global[int]] = Field(validation_alias=AliasPath("data", "mediaProfileNumber"))

--- a/catalystwan/models/policy/definition/dns_security.py
+++ b/catalystwan/models/policy/definition/dns_security.py
@@ -24,7 +24,7 @@ class TargetVpn(BaseModel):
         default=True, validation_alias="localDomainBypassEnabled", serialization_alias="localDomainBypassEnabled"
     )
 
-    uid: int
+    uid: Optional[int] = Field(default=None)
     umbrella_default: bool = Field(validation_alias="umbrellaDefault", serialization_alias="umbrellaDefault")
     vpns: List[VpnId]
 

--- a/catalystwan/models/policy/definition/zone_based_firewall.py
+++ b/catalystwan/models/policy/definition/zone_based_firewall.py
@@ -24,6 +24,7 @@ from catalystwan.models.policy.policy_definition import (
     DestinationPortEntry,
     DestinationPortListEntry,
     DestinationScalableGroupTagListEntry,
+    DestinationSecurityGroupEntry,
     LogAction,
     Match,
     PolicyActionBase,
@@ -45,6 +46,7 @@ from catalystwan.models.policy.policy_definition import (
     SourcePortEntry,
     SourcePortListEntry,
     SourceScalableGroupTagListEntry,
+    SourceSecurityGroupEntry,
 )
 
 ZoneBasedFWPolicySequenceEntry = Annotated[
@@ -60,6 +62,7 @@ ZoneBasedFWPolicySequenceEntry = Annotated[
         DestinationPortEntry,
         DestinationPortListEntry,
         DestinationScalableGroupTagListEntry,
+        DestinationSecurityGroupEntry,
         ProtocolEntry,
         ProtocolNameEntry,
         ProtocolNameListEntry,
@@ -73,6 +76,7 @@ ZoneBasedFWPolicySequenceEntry = Annotated[
         SourcePortEntry,
         SourcePortListEntry,
         SourceScalableGroupTagListEntry,
+        SourceSecurityGroupEntry,
     ],
     Field(discriminator="field"),
 ]
@@ -169,6 +173,9 @@ class ZoneBasedFWPolicySequence(PolicyDefinitionSequenceBase):
     def match_destination_port_list(self, data_prefix_lists: List[UUID]) -> None:
         self._insert_match(DestinationPortListEntry(ref=data_prefix_lists))
 
+    def match_destination_security_group_list(self, security_group_list: List[UUID]) -> None:
+        self._insert_match(DestinationSecurityGroupEntry(ref=security_group_list))
+
     def match_protocols(self, protocols: Set[int]) -> None:
         self._insert_match(ProtocolEntry.from_protocol_set(protocols))
 
@@ -209,6 +216,9 @@ class ZoneBasedFWPolicySequence(PolicyDefinitionSequenceBase):
 
     def match_source_port_list(self, port_list_id: List[UUID]) -> None:
         self._insert_match(SourcePortListEntry(ref=port_list_id))
+
+    def match_source_security_group_list(self, security_group_list: List[UUID]) -> None:
+        self._insert_match(SourceSecurityGroupEntry(ref=security_group_list))
 
 
 class ZoneBasedFWPolicyEntry(BaseModel):

--- a/catalystwan/models/policy/list/preferred_color_group.py
+++ b/catalystwan/models/policy/list/preferred_color_group.py
@@ -18,13 +18,15 @@ class ColorGroupPreference(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     color_preference: Set[TLOCColor] = Field(serialization_alias="colorPreference", validation_alias="colorPreference")
-    path_preference: PathPreference = Field(serialization_alias="pathPreference", validation_alias="pathPreference")
+    path_preference: Optional[PathPreference] = Field(
+        default=None, serialization_alias="pathPreference", validation_alias="pathPreference"
+    )
 
     _color_pref = field_validator("color_preference", mode="before")(str_as_str_list)
 
     @staticmethod
     def from_color_set_and_path(
-        color_preference: Set[TLOCColor], path_preference: PathPreference
+        color_preference: Set[TLOCColor], path_preference: Optional[PathPreference] = None
     ) -> "ColorGroupPreference":
         return ColorGroupPreference(color_preference=color_preference, path_preference=path_preference)
 
@@ -54,9 +56,9 @@ class PreferredColorGroupList(PolicyListBase):
 
     def assign_color_groups(
         self,
-        primary: Tuple[Set[TLOCColor], PathPreference],
-        secondary: Optional[Tuple[Set[TLOCColor], PathPreference]] = None,
-        tertiary: Optional[Tuple[Set[TLOCColor], PathPreference]] = None,
+        primary: Tuple[Set[TLOCColor], Optional[PathPreference]],
+        secondary: Optional[Tuple[Set[TLOCColor], Optional[PathPreference]]] = None,
+        tertiary: Optional[Tuple[Set[TLOCColor], Optional[PathPreference]]] = None,
     ) -> PreferredColorGroupListEntry:
         primary_preference = ColorGroupPreference.from_color_set_and_path(*primary)
         secondary_preference = (

--- a/catalystwan/models/policy/policy_definition.py
+++ b/catalystwan/models/policy/policy_definition.py
@@ -837,6 +837,11 @@ class SourceScalableGroupTagListEntry(BaseModel):
     ref: SpaceSeparatedUUIDList
 
 
+class SourceSecurityGroupEntry(BaseModel):
+    field: Literal["sourceSecurityGroup"] = "sourceSecurityGroup"
+    ref: SpaceSeparatedUUIDList
+
+
 class DestinationPortListEntry(BaseModel):
     field: Literal["destinationPortList"] = "destinationPortList"
     ref: SpaceSeparatedUUIDList = Field(
@@ -846,6 +851,11 @@ class DestinationPortListEntry(BaseModel):
 
 class DestinationScalableGroupTagListEntry(BaseModel):
     field: Literal["destinationScalableGroupTagList"] = "destinationScalableGroupTagList"
+    ref: SpaceSeparatedUUIDList
+
+
+class DestinationSecurityGroupEntry(BaseModel):
+    field: Literal["destinationSecurityGroup"] = "destinationSecurityGroup"
     ref: SpaceSeparatedUUIDList
 
 
@@ -1298,6 +1308,7 @@ MatchEntry = Annotated[
         DestinationPortListEntry,
         DestinationRegionEntry,
         DestinationScalableGroupTagListEntry,
+        DestinationSecurityGroupEntry,
         DestinationVpnEntry,
         DNSAppListEntry,
         DNSEntry,
@@ -1347,6 +1358,7 @@ MatchEntry = Annotated[
         SourcePortEntry,
         SourcePortListEntry,
         SourceScalableGroupTagListEntry,
+        SourceSecurityGroupEntry,
         SourceVpnEntry,
         TCPEntry,
         TLOCEntry,

--- a/catalystwan/models/policy/security.py
+++ b/catalystwan/models/policy/security.py
@@ -94,7 +94,7 @@ class SecurityPolicySettings(BaseModel):
     tcp_syn_flood_limit: Optional[str] = Field(
         default=None, serialization_alias="tcpSynFloodLimit", validation_alias="tcpSynFloodLimit"
     )
-    high_speed_logging: Optional[HighSpeedLoggingEntry] = Field(
+    high_speed_logging: Union[HighSpeedLoggingEntry, HighSpeedLoggingList, None] = Field(
         default=None, serialization_alias="highSpeedLogging", validation_alias="highSpeedLogging"
     )
     audit_trail: Optional[str] = Field(default=None, serialization_alias="auditTrail", validation_alias="auditTrail")
@@ -117,7 +117,7 @@ class UnifiedSecurityPolicySettings(BaseModel):
     max_incomplete_icmp_limit: Optional[str] = Field(
         default=None, serialization_alias="maxIncompleteIcmpLimit", validation_alias="maxIncompleteIcmpLimit"
     )
-    high_speed_logging: Optional[HighSpeedLoggingList] = Field(
+    high_speed_logging: Union[HighSpeedLoggingEntry, HighSpeedLoggingList, None] = Field(
         default=None, serialization_alias="highSpeedLogging", validation_alias="highSpeedLogging"
     )
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
# Pull Request summary:
multiple model fixes

# Description of changes:
- add src/dst security group as firewall match entries
- allow additional highSpeedLogging field format in security policy settings
- target vpn uid is optional in dns security policy definition
- path preference is optional in preferred color group list
- media profile dmtf is a list and can have default option type
- allow ike_remote_id to be IPv4Address in lan/vpn/interface/ipsec parcel

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
