### PR TITLE
Add backwards compatible tloccolor

### DIFF
--- a/catalystwan/models/common.py
+++ b/catalystwan/models/common.py
@@ -325,6 +325,9 @@ Protocol = Literal["tcp", "udp"]
 TLOCColor = Literal[
     "default",
     "mpls",
+    "metro ethernet",
+    "biz internet",
+    "public internet",
     "metro-ethernet",
     "biz-internet",
     "public-internet",


### PR DESCRIPTION
# Pull Request summary:
wan/vpn/interface/cellular uses literals without dash till 20.14
