### PR TITLE
[dev]: add aggregrate origin protocol as 20.16 typo

### DIFF
--- a/catalystwan/models/common.py
+++ b/catalystwan/models/common.py
@@ -520,6 +520,7 @@ MultiRegionRole = Literal[
 ]
 
 OriginProtocol = Literal[
+    "aggregrate",  # 20.16 typo
     "aggregate",
     "bgp",
     "bgp-external",


### PR DESCRIPTION
# Pull Request summary:
In vManage 20.16 there is typo for origin protocol "aggregrate" instead of "aggregate".


# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
