### PR TITLE
[dev]: add missing values for Speed literal

### DIFF
--- a/catalystwan/models/common.py
+++ b/catalystwan/models/common.py
@@ -946,13 +946,7 @@ MediaType = Literal[
     "sfp",
 ]
 
-Speed = Literal[
-    "10",
-    "100",
-    "1000",
-    "10000",
-    "2500",
-]
+Speed = Literal["10", "100", "1000", "2500", "5000", "10000", "25000"]
 
 EthernetNatType = Literal["pool", "loopback", "interface"]
 


### PR DESCRIPTION
# Pull Request summary:
Added missing values for common Speed literal

# Description of changes:
Added missing values in common Speed to reflect 20.18 schema:
```py
"speedDef": {
    "enum": [
        "10",
        "100",
        "1000",
        "2500",
        "5000",
        "10000",
        "25000"
        ],
  "type": "string"
}
```
It is common literal for `Ethernet` and `Switchport`

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
