### PR TITLE
[dev]: ethernet 20.18 fields

### DIFF
--- a/catalystwan/models/configuration/feature_profile/common.py
+++ b/catalystwan/models/configuration/feature_profile/common.py
@@ -663,6 +663,24 @@ class InterfaceStaticIPv4Address(BaseModel):
     static: StaticIPv4AddressConfig = Field(default_factory=StaticIPv4AddressConfig)
 
 
+AddressType = Literal["dynamic", "static"]
+
+
+class EitherIPv4AddressConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+
+    address_type: Union[Global[AddressType], Variable] = Field(
+        serialization_alias="addressType", validation_alias="addressType"
+    )
+    static: Optional[StaticIPv4AddressConfig] = Field(default=None)
+    dynamic: Optional[DynamicDhcpDistance] = Field(default=None)
+
+
+class InterfaceEitherIPv4Address(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+    either: EitherIPv4AddressConfig = Field()
+
+
 class DynamicIPv6Dhcp(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
 

--- a/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
@@ -17,11 +17,14 @@ from typing_extensions import Annotated
 from catalystwan.api.configuration_groups.parcel import Default, Global, Variable, _ParcelBase
 from catalystwan.models.common import EthernetDuplexMode, MediaType, VersionedField
 from catalystwan.models.configuration.feature_profile.common import (
+    AddressType,
     Arp,
     DynamicDhcpDistance,
+    DynamicIPv6Dhcp,
     EthernetNatAttributesIpv4,
     InterfaceDynamicIPv4Address,
     InterfaceDynamicIPv6Address,
+    InterfaceEitherIPv4Address,
     InterfaceStaticIPv4Address,
     RefIdItem,
     StaticIPv4Address,
@@ -164,6 +167,21 @@ class InterfaceStaticIPv6Address(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
 
     static: StaticIPv6AddressConfig
+
+
+class EitherIPv6AddressConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+
+    address_type: Union[Global[AddressType], Variable] = Field(
+        serialization_alias="addressType", validation_alias="addressType"
+    )
+    static: Optional[StaticIPv6AddressConfig] = Field(default=None)
+    dynamic: Optional[DynamicIPv6Dhcp] = Field(default=None)
+
+
+class InterfaceEitherIPv6Address(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+    either: EitherIPv6AddressConfig = Field()
 
 
 class NatAttributesIPv6(BaseModel):
@@ -334,15 +352,15 @@ class InterfaceEthernetParcel(_ParcelBase):
     ethernet_description: Optional[Union[Global[str], Variable, Default[None]]] = Field(
         default=Default[None](value=None), validation_alias=AliasPath("data", "description")
     )
-    interface_ip_address: Optional[Union[InterfaceDynamicIPv4Address, InterfaceStaticIPv4Address]] = Field(
-        validation_alias=AliasPath("data", "intfIpAddress"), default=None
-    )
+    interface_ip_address: Optional[
+        Union[InterfaceDynamicIPv4Address, InterfaceStaticIPv4Address, InterfaceEitherIPv4Address]
+    ] = Field(validation_alias=AliasPath("data", "intfIpAddress"), default=None)
     dhcp_helper: Optional[Union[Variable, Global[List[str]], Default[None]]] = Field(
         validation_alias=AliasPath("data", "dhcpHelper"), default=None
     )
-    interface_ipv6_address: Optional[Union[InterfaceDynamicIPv6Address, InterfaceStaticIPv6Address]] = Field(
-        validation_alias=AliasPath("data", "intfIpV6Address"), default=None
-    )
+    interface_ipv6_address: Optional[
+        Union[InterfaceDynamicIPv6Address, InterfaceStaticIPv6Address, InterfaceEitherIPv6Address]
+    ] = Field(validation_alias=AliasPath("data", "intfIpV6Address"), default=None)
     nat: Union[Global[bool], Default[bool]] = Field(
         validation_alias=AliasPath("data", "nat"), default=Default[bool](value=False)
     )
@@ -398,6 +416,15 @@ class InterfaceEthernetParcel(_ParcelBase):
             raise ValueError("Interface IP Address is already dynamic")
 
         secondary_ip_address = StaticIPv4Address(ip_address=ip_address, subnet_mask=subnet_mask)
-        if self.interface_ip_address.static.secondary_ip_address is None:
-            self.interface_ip_address.static.secondary_ip_address = []
-        self.interface_ip_address.static.secondary_ip_address.append(secondary_ip_address)
+
+        if isinstance(self.interface_ip_address, InterfaceStaticIPv4Address):
+            if self.interface_ip_address.static.secondary_ip_address is None:
+                self.interface_ip_address.static.secondary_ip_address = []
+            self.interface_ip_address.static.secondary_ip_address.append(secondary_ip_address)
+
+        if isinstance(self.interface_ip_address, InterfaceEitherIPv4Address):
+            if self.interface_ip_address.either.static is None:
+                raise ValueError("Missing static primary IP Address")
+            if self.interface_ip_address.either.static.secondary_ip_address is None:
+                self.interface_ip_address.either.static.secondary_ip_address = []
+            self.interface_ip_address.either.static.secondary_ip_address.append(secondary_ip_address)

--- a/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
@@ -281,19 +281,20 @@ class Trustsec(BaseModel):
     propogate: Annotated[
         Optional[Union[Global[bool], Default[bool]]], VersionedField(versions="<=20.12", forbidden=True)
     ] = Default[bool](value=True)
-    security_group_tag: Optional[Union[Global[int], Variable, Default[None]]] = Field(
+    security_group_tag: Optional[Union[Global[int], Variable, Default[str], Default[None]]] = Field(
         serialization_alias="securityGroupTag", validation_alias="securityGroupTag", default=None
     )
     enable_enforced_propogation: Union[Global[bool], Default[None]] = Field(
-        default=Default[None](value=None),
+        default=Default[None](),
         serialization_alias="enableEnforcedPropogation",
         validation_alias="enableEnforcedPropogation",
     )
-    enforced_security_group_tag: Union[Global[int], Variable, Default[None]] = Field(
-        default=Default[None](value=None),
+    enforced_security_group_tag: Union[Global[int], Variable, Default[str], Default[None]] = Field(
+        default=Default[None](),
         serialization_alias="enforcedSecurityGroupTag",
         validation_alias="enforcedSecurityGroupTag",
     )
+    trusted: Optional[Union[Global[bool], Default[bool]]] = Field(default=None)
 
     @model_serializer(mode="wrap", when_used="json")
     def serialize(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> Dict[str, Any]:

--- a/catalystwan/models/configuration/feature_profile/sdwan/transport/management/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/transport/management/ethernet.py
@@ -7,8 +7,10 @@ from pydantic import AliasPath, BaseModel, ConfigDict, Field
 from catalystwan.api.configuration_groups.parcel import Default, Global, Variable, _ParcelBase
 from catalystwan.models.common import EthernetDuplexMode, MediaType, Speed
 from catalystwan.models.configuration.feature_profile.common import (
+    AddressType,
     Arp,
     InterfaceDynamicIPv4Address,
+    InterfaceEitherIPv4Address,
     InterfaceStaticIPv4Address,
 )
 
@@ -48,6 +50,21 @@ class InterfaceStaticIPv6Address(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
 
     static: StaticIPv6AddressConfig
+
+
+class EitherIPv6AddressConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+
+    address_type: Union[Global[AddressType], Variable] = Field(
+        serialization_alias="addressType", validation_alias="addressType"
+    )
+    static: Optional[StaticIPv6AddressConfig] = Field(default=None)
+    dynamic: Optional[DhcpClient] = Field(default=None)
+
+
+class InterfaceEitherIPv6Address(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+    either: EitherIPv6AddressConfig = Field()
 
 
 class Advanced(BaseModel):
@@ -98,7 +115,7 @@ class InterfaceEthernetParcel(_ParcelBase):
     interface_description: Union[Variable, Global[str], Default[None]] = Field(
         default=Default[None](value=None), validation_alias=AliasPath("data", "description")
     )
-    intf_ip_address: Union[InterfaceDynamicIPv4Address, InterfaceStaticIPv4Address] = Field(
+    intf_ip_address: Union[InterfaceDynamicIPv4Address, InterfaceStaticIPv4Address, InterfaceEitherIPv4Address] = Field(
         validation_alias=AliasPath("data", "intfIpAddress")
     )
     shutdown: Union[Variable, Global[bool], Default[bool]] = Field(
@@ -113,9 +130,9 @@ class InterfaceEthernetParcel(_ParcelBase):
     dhcp_helper: Optional[Union[Variable, Default[None], Global[List[str]]]] = Field(
         default=None, validation_alias=AliasPath("data", "dhcpHelper")
     )
-    intf_ip_v6_address: Optional[Union[InterfaceDynamicIPv6Address, InterfaceStaticIPv6Address]] = Field(
-        default=None, validation_alias=AliasPath("data", "intfIpV6Address")
-    )
+    intf_ip_v6_address: Optional[
+        Union[InterfaceDynamicIPv6Address, InterfaceStaticIPv6Address, InterfaceEitherIPv6Address]
+    ] = Field(default=None, validation_alias=AliasPath("data", "intfIpV6Address"))
     iperf_server: Optional[Union[Variable, Global[str], Default[None]]] = Field(
         default=None, validation_alias=AliasPath("data", "iperfServer")
     )

--- a/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/ethernet.py
@@ -16,12 +16,15 @@ from catalystwan.models.common import (
 )
 from catalystwan.models.configuration.feature_profile.common import (
     AclQos,
+    AddressType,
     AllowService,
     Arp,
+    DynamicIPv6Dhcp,
     Encapsulation,
     EthernetNatAttributesIpv4,
     InterfaceDynamicIPv4Address,
     InterfaceDynamicIPv6Address,
+    InterfaceEitherIPv4Address,
     InterfaceStaticIPv4Address,
     MultiRegionFabric,
     RefIdItem,
@@ -147,6 +150,21 @@ class Static(BaseModel):
 
 class InterfaceStaticIPv6Address(BaseModel):
     static: Static = Field()
+
+
+class EitherIPv6AddressConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+
+    address_type: Union[Global[AddressType], Variable] = Field(
+        serialization_alias="addressType", validation_alias="addressType"
+    )
+    static: Optional[Static] = Field(default=None)
+    dynamic: Optional[DynamicIPv6Dhcp] = Field(default=None)
+
+
+class InterfaceEitherIPv6Address(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+    either: EitherIPv6AddressConfig = Field()
 
 
 class Tunnel(BaseModel):
@@ -314,9 +332,9 @@ class InterfaceEthernetParcel(_ParcelBase):
         default_factory=list, validation_alias=AliasPath("data", "encapsulation"), description="Encapsulation for TLOC"
     )
     interface_name: Union[Variable, Global[str]] = Field(validation_alias=AliasPath("data", "interfaceName"))
-    interface_ip_address: Optional[Union[InterfaceDynamicIPv4Address, InterfaceStaticIPv4Address]] = Field(
-        validation_alias=AliasPath("data", "intfIpAddress"), default=None
-    )
+    interface_ip_address: Optional[
+        Union[InterfaceDynamicIPv4Address, InterfaceStaticIPv4Address, InterfaceEitherIPv4Address]
+    ] = Field(validation_alias=AliasPath("data", "intfIpAddress"), default=None)
     interface_description: Optional[Union[Variable, Global[str], Default[None]]] = Field(
         default=None, validation_alias=AliasPath("data", "description")
     )
@@ -354,9 +372,9 @@ class InterfaceEthernetParcel(_ParcelBase):
     dhcp_helper: Optional[Union[Variable, Default[None], Global[List[str]]]] = Field(
         default=None, validation_alias=AliasPath("data", "dhcpHelper")
     )
-    intf_ip_v6_address: Optional[Union[InterfaceDynamicIPv6Address, InterfaceStaticIPv6Address]] = Field(
-        default=None, validation_alias=AliasPath("data", "intfIpV6Address")
-    )
+    intf_ip_v6_address: Optional[
+        Union[InterfaceDynamicIPv6Address, InterfaceStaticIPv6Address, InterfaceEitherIPv6Address]
+    ] = Field(default=None, validation_alias=AliasPath("data", "intfIpV6Address"))
     iperf_server: Optional[Union[Variable, Global[str], Default[None]]] = Field(
         default=None, validation_alias=AliasPath("data", "iperfServer")
     )

--- a/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/ethernet.py
@@ -167,6 +167,31 @@ class InterfaceEitherIPv6Address(BaseModel):
     either: EitherIPv6AddressConfig = Field()
 
 
+class Trustsec(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+
+    enable_sgt_propogation: Union[Global[bool], Default[bool]] = Field(
+        serialization_alias="enableSGTPropogation",
+        validation_alias="enableSGTPropogation",
+        default=Default[bool](value=False),
+    )
+    propagate: Optional[Union[Global[bool], Default[bool]]] = Default[bool](value=True)
+    security_group_tag: Optional[Union[Global[int], Variable, Default[str]]] = Field(
+        serialization_alias="securityGroupTag", validation_alias="securityGroupTag", default=None
+    )
+    enable_enforced_propogation: Union[Global[bool], Default[None]] = Field(
+        default=Default[None](),
+        serialization_alias="enableEnforcedPropogation",
+        validation_alias="enableEnforcedPropogation",
+    )
+    enforced_security_group_tag: Union[Global[int], Variable, Default[str]] = Field(
+        default=Default[str](value=""),
+        serialization_alias="enforcedSecurityGroupTag",
+        validation_alias="enforcedSecurityGroupTag",
+    )
+    trusted: Optional[Union[Global[bool], Default[bool]]] = Field(default=None)
+
+
 class Tunnel(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
     bandwidth_percent: Optional[Union[Variable, Default[int], Global[int]]] = Field(
@@ -348,6 +373,7 @@ class InterfaceEthernetParcel(_ParcelBase):
         default=Global[bool](value=False), validation_alias=AliasPath("data", "tunnelInterface")
     )
     acl_qos: Optional[AclQos] = Field(default=None, validation_alias=AliasPath("data", "aclQos"), description="ACL/QOS")
+    trustsec: Optional[Trustsec] = Field(validation_alias=AliasPath("data", "trustsec"), default=None)
     advanced: Optional[Advanced] = Field(
         default=None, validation_alias=AliasPath("data", "advanced"), description="Advanced Attributes"
     )


### PR DESCRIPTION
# Pull Request summary:
Added fields introduced in vManage 20.18 for interface/ethernet

# Description of changes:
Added either option for ip address type.
Added changes in trustsec for ethernet.

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
