### PR TITLE
[dev]: add DHCP dual home enable field

### DIFF
--- a/catalystwan/models/configuration/feature_profile/sdwan/service/dhcp_server.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/dhcp_server.py
@@ -125,3 +125,6 @@ class LanVpnDhcpServerParcel(_ParcelBase):
     option_code: Optional[List[OptionCode]] = Field(
         default=None, validation_alias=AliasPath("data", "optionCode"), description="Configure Options Code"
     )
+    dhcp_ha_enable: Optional[Union[Variable, Global[bool], Default[bool]]] = Field(
+        default=None, validation_alias=AliasPath("data", "dhcpHaEnable")
+    )

--- a/catalystwan/models/configuration/feature_profile/sdwan/service/dhcp_server.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/dhcp_server.py
@@ -126,5 +126,5 @@ class LanVpnDhcpServerParcel(_ParcelBase):
         default=None, validation_alias=AliasPath("data", "optionCode"), description="Configure Options Code"
     )
     dhcp_ha_enable: Optional[Union[Variable, Global[bool], Default[bool]]] = Field(
-        default=None, validation_alias=AliasPath("data", "dhcpHaEnable")
+        default=None, validation_alias=AliasPath("data", "dhcpHaEnable"), description="Available only in >= 20.18.2"
     )


### PR DESCRIPTION
# Pull Request summary:
Added DHCP dual home enable field for LanVpnDhcpServerParcel

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
