### PR TITLE
[dev]: add new types for signature set in IntrusionPrevention

### DIFF
--- a/catalystwan/models/common.py
+++ b/catalystwan/models/common.py
@@ -2049,3 +2049,7 @@ SpaceSeparatedServiceAreaList = Annotated[
     PlainSerializer(lambda x: " ".join(map(str, x)), return_type=str, when_used="json-unless-none"),
     BeforeValidator(str_as_service_area_list),
 ]
+
+IntrusionPreventionSignatureSet = Literal["balanced", "connectivity", "security", "max-detect"]
+IntrusionPreventionInspectionMode = Literal["protection", "detection"]
+IntrusionPreventionLogLevel = Literal["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/security/intrusion_prevention.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/security/intrusion_prevention.py
@@ -6,11 +6,14 @@ from uuid import UUID
 from pydantic import AliasPath, ConfigDict, Field
 
 from catalystwan.api.configuration_groups.parcel import Global, _ParcelBase
+from catalystwan.models.common import (
+    IntrusionPreventionInspectionMode,
+    IntrusionPreventionLogLevel,
+    IntrusionPreventionSignatureSet,
+)
 from catalystwan.models.configuration.feature_profile.common import RefIdItem
 
-SignatureSet = Literal["balanced", "connectivity", "security", "max-detect", "no-rules-active"]
-InspectionMode = Literal["detection", "protection"]
-LogLevel = Literal["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]
+SignatureSet = Literal[IntrusionPreventionSignatureSet, "no-rules-active"]
 
 
 class IntrusionPreventionParcel(_ParcelBase):
@@ -19,14 +22,15 @@ class IntrusionPreventionParcel(_ParcelBase):
     signature_set: Global[SignatureSet] = Field(
         default=Global[SignatureSet](value="balanced"), validation_alias=AliasPath("data", "signatureSet")
     )
-    inspection_mode: Global[InspectionMode] = Field(
-        default=Global[InspectionMode](value="detection"), validation_alias=AliasPath("data", "inspectionMode")
+    inspection_mode: Global[IntrusionPreventionInspectionMode] = Field(
+        default=Global[IntrusionPreventionInspectionMode](value="detection"),
+        validation_alias=AliasPath("data", "inspectionMode"),
     )
     signature_allowed_list: Optional[RefIdItem] = Field(
         default=None, validation_alias=AliasPath("data", "signatureAllowedList")
     )
-    log_level: Global[LogLevel] = Field(
-        default=Global[LogLevel](value="error"), validation_alias=AliasPath("data", "logLevel")
+    log_level: Global[IntrusionPreventionLogLevel] = Field(
+        default=Global[IntrusionPreventionLogLevel](value="error"), validation_alias=AliasPath("data", "logLevel")
     )
     custom_signature: Global[bool] = Field(
         default=Global[bool](value=False), validation_alias=AliasPath("data", "customSignature")
@@ -38,9 +42,9 @@ class IntrusionPreventionParcel(_ParcelBase):
         parcel_name: str,
         parcel_description: str,
         signature_set: SignatureSet = "balanced",
-        inspection_mode: InspectionMode = "detection",
+        inspection_mode: IntrusionPreventionInspectionMode = "detection",
         signature_allowed_list: Optional[UUID] = None,
-        log_level: LogLevel = "error",
+        log_level: IntrusionPreventionLogLevel = "error",
         custom_signature: bool = False,
     ) -> "IntrusionPreventionParcel":
         sal: Optional[RefIdItem] = None
@@ -51,8 +55,8 @@ class IntrusionPreventionParcel(_ParcelBase):
             parcel_name=parcel_name,
             parcel_description=parcel_description,
             signature_set=Global[SignatureSet](value=signature_set),
-            inspection_mode=Global[InspectionMode](value=inspection_mode),
+            inspection_mode=Global[IntrusionPreventionInspectionMode](value=inspection_mode),
             signature_allowed_list=sal,
-            log_level=Global[LogLevel](value=log_level),
+            log_level=Global[IntrusionPreventionLogLevel](value=log_level),
             custom_signature=Global[bool](value=custom_signature),
         )

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/security/intrusion_prevention.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/security/intrusion_prevention.py
@@ -8,7 +8,7 @@ from pydantic import AliasPath, ConfigDict, Field
 from catalystwan.api.configuration_groups.parcel import Global, _ParcelBase
 from catalystwan.models.configuration.feature_profile.common import RefIdItem
 
-SignatureSet = Literal["balanced", "connectivity", "security"]
+SignatureSet = Literal["balanced", "connectivity", "security", "max-detect", "no-rules-active"]
 InspectionMode = Literal["detection", "protection"]
 LogLevel = Literal["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]
 

--- a/catalystwan/models/policy/definition/intrusion_prevention.py
+++ b/catalystwan/models/policy/definition/intrusion_prevention.py
@@ -4,7 +4,13 @@ from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from catalystwan.models.common import PolicyModeType, VpnId
+from catalystwan.models.common import (
+    IntrusionPreventionInspectionMode,
+    IntrusionPreventionLogLevel,
+    IntrusionPreventionSignatureSet,
+    PolicyModeType,
+    VpnId,
+)
 from catalystwan.models.policy.policy_definition import (
     PolicyDefinitionBase,
     PolicyDefinitionGetResponse,
@@ -12,19 +18,21 @@ from catalystwan.models.policy.policy_definition import (
     Reference,
 )
 
-SignatureSetType = Literal["balanced", "connectivity", "security", "max-detect"]
-InspectionModeType = Literal["protection", "detection"]
-LogLevel = Literal["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]
-
 
 class IntrusionPreventionDefinition(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    signature_set: SignatureSetType = Field(validation_alias="signatureSet", serialization_alias="signatureSet")
-    inspection_mode: InspectionModeType = Field(validation_alias="inspectionMode", serialization_alias="inspectionMode")
+    signature_set: IntrusionPreventionSignatureSet = Field(
+        validation_alias="signatureSet", serialization_alias="signatureSet"
+    )
+    inspection_mode: IntrusionPreventionInspectionMode = Field(
+        validation_alias="inspectionMode", serialization_alias="inspectionMode"
+    )
     signature_white_list: Optional[Reference] = Field(
         default=None, validation_alias="signatureWhiteList", serialization_alias="signatureWhiteList"
     )
-    log_level: Optional[LogLevel] = Field(default="error", validation_alias="logLevel", serialization_alias="logLevel")
+    log_level: Optional[IntrusionPreventionLogLevel] = Field(
+        default="error", validation_alias="logLevel", serialization_alias="logLevel"
+    )
     logging: List[str] = Field(default_factory=list)
     target_vpns: List[VpnId] = Field(
         default_factory=list, validation_alias="targetVpns", serialization_alias="targetVpns"

--- a/catalystwan/models/policy/definition/intrusion_prevention.py
+++ b/catalystwan/models/policy/definition/intrusion_prevention.py
@@ -12,7 +12,7 @@ from catalystwan.models.policy.policy_definition import (
     Reference,
 )
 
-SignatureSetType = Literal["balanced", "connectivity", "security"]
+SignatureSetType = Literal["balanced", "connectivity", "security", "max-detect"]
 InspectionModeType = Literal["protection", "detection"]
 LogLevel = Literal["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]
 


### PR DESCRIPTION
# Pull Request summary:
Added new types for signature set in `IntrusionPrevention` introduced in vManage 20.18

# Description of changes:
Added `max-detect, no-rules-active` for `SignatureSet` in UX2
Added `max-detect` for `SignatureSetType` in UX1

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
