### PR TITLE
[dev]: multicast SendRpAnnounce and access_list changes 

### DIFF
--- a/catalystwan/integration_tests/feature_profile/sdwan/test_service.py
+++ b/catalystwan/integration_tests/feature_profile/sdwan/test_service.py
@@ -90,8 +90,9 @@ from catalystwan.models.configuration.feature_profile.sdwan.service.multicast im
     PimAttributes,
     PimBsrAttributes,
     PimInterfaceParameters,
-    RPAnnounce,
     RpDiscoveryScope,
+    SendRpAnnounce,
+    SendRpDiscovery,
     SsmAttributes,
     SsmFlag,
     StaticJoin,
@@ -616,10 +617,10 @@ class TestServiceFeatureProfileModels(TestCaseBase):
                 auto_rp=AutoRpAttributes(
                     enable_auto_rp_flag=as_global(False),
                     send_rp_announce_list=[
-                        RPAnnounce(interface_name=as_global("GigabitEthernet0/0/0"), scope=as_global(3))
+                        SendRpAnnounce(interface_name=as_global("GigabitEthernet0/0/0"), scope=as_global(3))
                     ],
                     send_rp_discovery=[
-                        RPAnnounce(interface_name=as_global("GigabitEthernet0/0/0"), scope=as_global(3))
+                        SendRpDiscovery(interface_name=as_global("GigabitEthernet0/0/0"), scope=as_global(3))
                     ],
                 ),
                 pim_bsr=PimBsrAttributes(

--- a/catalystwan/models/configuration/feature_profile/sdwan/service/multicast.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/multicast.py
@@ -98,11 +98,13 @@ class StaticRpAddress(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
 
     address: Union[Global[IPv4Address], Variable]
-    access_list: Union[Global[str], Variable] = Field(serialization_alias="accessList", validation_alias="accessList")
+    access_list: Union[Global[str], Variable, Default[None]] = Field(
+        serialization_alias="accessList", validation_alias="accessList"
+    )
     override: Optional[Union[Global[bool], Variable, Default[bool]]] = Default[bool](value=False)
 
 
-class RPAnnounce(BaseModel):
+class SendRpDiscovery(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
 
     interface_name: Union[Global[str], Variable] = Field(
@@ -111,16 +113,29 @@ class RPAnnounce(BaseModel):
     scope: Union[Global[int], Variable]
 
 
+class SendRpAnnounce(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
+
+    interface_name: Union[Global[str], Variable] = Field(
+        validation_alias="interfaceName", serialization_alias="interfaceName"
+    )
+    scope: Union[Global[int], Variable] = Field()
+    group_list: Optional[Union[Global[str], Variable, Default[None]]] = Field(
+        default=None, validation_alias="groupList", serialization_alias="groupList"
+    )
+    interval: Optional[Union[Default[None], Global[int], Variable]] = Field(default=None)
+
+
 class AutoRpAttributes(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
 
     enable_auto_rp_flag: Optional[Union[Global[bool], Variable, Default[bool]]] = Field(
         serialization_alias="enableAutoRPFlag", validation_alias="enableAutoRPFlag", default=Default[bool](value=False)
     )
-    send_rp_announce_list: Optional[List[RPAnnounce]] = Field(
+    send_rp_announce_list: Optional[List[SendRpAnnounce]] = Field(
         serialization_alias="sendRpAnnounceList", validation_alias="sendRpAnnounceList", default=None
     )
-    send_rp_discovery: Optional[List[RPAnnounce]] = Field(
+    send_rp_discovery: Optional[List[SendRpDiscovery]] = Field(
         serialization_alias="sendRpDiscovery", validation_alias="sendRpDiscovery", default=None
     )
 


### PR DESCRIPTION
# Pull Request summary:
Add acl and internal for rp announce in multicast parcel
Set acl optional for static rp addr in multicast
Split `RPAnnounce` into two separate fields: `SendRpDiscovery` and `SendRpAnnounce`

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
