### PR TITLE
[dev]: add get or create method to service feature profile builder for dhcp server

### DIFF
--- a/catalystwan/api/builders/feature_profiles/service.py
+++ b/catalystwan/api/builders/feature_profiles/service.py
@@ -69,6 +69,7 @@ class ServiceFeatureProfileBuilder(TrackerMixin):
         self._interfaces_with_attached_dhcp_server: Dict[str, LanVpnDhcpServerParcel] = {}
         # Trackers
         self.init_tracker()
+        self._dhcp_server_uuids: Dict[str, UUID] = {}
 
     def add_profile_name_and_description(self, feature_profile: FeatureProfileCreationPayload) -> None:
         """
@@ -216,7 +217,7 @@ class ServiceFeatureProfileBuilder(TrackerMixin):
                         continue
 
                     if dhcp_server:
-                        dhcp_server_uuid = self._create_parcel(profile_uuid, dhcp_server)
+                        dhcp_server_uuid = self._get_or_create_dhcp_server_uuid(profile_uuid, dhcp_server)
                         if dhcp_server_uuid is not None:
                             with handle_association_request(self.build_report, sub_parcel):
                                 self._endpoints.associate_dhcp_server_with_vpn_interface(
@@ -246,3 +247,11 @@ class ServiceFeatureProfileBuilder(TrackerMixin):
     @handle_create_parcel
     def _create_parcel(self, profile_uuid: UUID, parcel: AnyServiceParcel, vpn_uuid: Optional[None] = None) -> UUID:
         return self._api.create_parcel(profile_uuid, parcel, vpn_uuid).id
+
+    def _get_or_create_dhcp_server_uuid(self, profile_uuid: UUID, dhcp_server: LanVpnDhcpServerParcel) -> UUID:
+        existing_uuid = self._dhcp_server_uuids.get(dhcp_server.parcel_name)
+        if existing_uuid:
+            return existing_uuid
+        dhcp_server_uuid = self._create_parcel(profile_uuid, dhcp_server)
+        self._dhcp_server_uuids[dhcp_server.parcel_name] = dhcp_server_uuid
+        return dhcp_server_uuid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.41.5dev0"
+version = "0.41.5dev1"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["sbasan <sbasan@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
Reuse already created `dhcp-server` in one service feature profile scope

# Description of changes:
Add a `_get_or_create_dhcp_server_uuid` method to prevent duplicate `dhcp-server` within `service feature profile`. The method first attempts to retrieve an existing parcel. In no matching parcel then it creates a new one.

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
