### PR TITLE
Include WAN edge inventory in device lookup

### DIFF
--- a/catalystwan/api/basic_api.py
+++ b/catalystwan/api/basic_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, List, Union
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
 from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed  # type: ignore
 
@@ -134,11 +134,104 @@ class DevicesAPI:
 
         return True if wait_for_state() else False
 
-    def get(self, rediscover: bool = False) -> DataSequence[Device]:
+    @staticmethod
+    def _first_present(*values: Any) -> Optional[str]:
+        for value in values:
+            if value is not None and value != "":
+                return str(value)
+        return None
+
+    @classmethod
+    def _device_from_inventory(cls, device_details) -> Device:
+        device_id = cls._first_present(
+            getattr(device_details, "device_id", None),
+            getattr(device_details, "device_ip", None),
+            getattr(device_details, "system_ip", None),
+            getattr(device_details, "management_system_ip", None),
+            getattr(device_details, "local_system_ip", None),
+        )
+        uuid = cls._first_present(getattr(device_details, "uuid", None), getattr(device_details, "chasis_number", None))
+        hostname = cls._first_present(
+            getattr(device_details, "host_name", None),
+            getattr(device_details, "ncs_device_name", None),
+            device_id,
+        )
+        local_system_ip = cls._first_present(
+            getattr(device_details, "local_system_ip", None),
+            getattr(device_details, "system_ip", None),
+            getattr(device_details, "device_ip", None),
+            device_id,
+        )
+
+        if device_id is None or uuid is None or hostname is None or local_system_ip is None:
+            raise ValueError(f"Incomplete device inventory entry: {device_details!r}")
+
+        return create_dataclass(
+            Device,
+            {
+                "uuid": uuid,
+                "personality": cls._first_present(getattr(device_details, "personality", None), Personality.EDGE.value),
+                "id": device_id,
+                "hostname": hostname,
+                "reachability": cls._first_present(
+                    getattr(device_details, "reachability", None), Reachability.UNKNOWN.value
+                ),
+                "local_system_ip": local_system_ip,
+                "status": cls._first_present(
+                    getattr(device_details, "device_state", None),
+                    getattr(device_details, "state", None),
+                    getattr(device_details, "validity", None),
+                ),
+                "model": cls._first_present(
+                    getattr(device_details, "device_model", None),
+                    getattr(device_details, "device_type", None),
+                ),
+                "site_id": cls._first_present(
+                    getattr(device_details, "site_id", None),
+                    getattr(device_details, "configured_site_id", None),
+                ),
+                "site_name": getattr(device_details, "site_name", None),
+            },
+        )
+
+    def _get_unmonitored_wan_edges(self, known_devices: DataSequence[Device]) -> DataSequence[Device]:
+        known_device_keys = {
+            value
+            for device in known_devices
+            for value in (device.uuid, device.id, device.hostname, device.local_system_ip)
+            if value
+        }
+        wan_edges = DataSequence(Device, [])
+
+        try:
+            device_details = self.session.endpoints.configuration_device_inventory.get_device_details("vedges")
+        except CatalystwanException as exc:
+            logger.debug("Skipping WAN edge inventory lookup: %s", exc)
+            return wan_edges
+
+        if not isinstance(device_details, DataSequence):
+            return wan_edges
+
+        for device_detail in device_details:
+            try:
+                device = self._device_from_inventory(device_detail)
+            except ValueError as exc:
+                logger.debug("Skipping WAN edge inventory entry: %s", exc)
+                continue
+
+            device_keys = {device.uuid, device.id, device.hostname, device.local_system_ip}
+            if device_keys.isdisjoint(known_device_keys):
+                wan_edges.append(device)
+                known_device_keys.update(device_keys)
+
+        return wan_edges
+
+    def get(self, rediscover: bool = False, include_inventory: bool = True) -> DataSequence[Device]:
         """Data sequence of all devices.
 
         Args:
             rediscover: Rediscover device request payload
+            include_inventory: Include WAN edge inventory entries that are not currently returned by device monitoring
 
         Returns:
             DataSequence[Device] of all devices
@@ -160,6 +253,9 @@ class DevicesAPI:
             params = {"deviceId": device_ids[i : i + self.max_params]}
             resp = self.session.get(url="/dataservice/device/system/info", params=params)
             devices_sys_info += resp.dataseq(Device)
+
+        if include_inventory:
+            devices_sys_info += self._get_unmonitored_wan_edges(devices_sys_info)
 
         return devices_sys_info
 

--- a/catalystwan/api/template_api.py
+++ b/catalystwan/api/template_api.py
@@ -39,7 +39,7 @@ from catalystwan.api.templates.models.security_vsmart_model import SecurityvSmar
 from catalystwan.api.templates.models.system_vsmart_model import SystemVsmart
 from catalystwan.dataclasses import Device, DeviceTemplateInfo, FeatureTemplateInfo, FeatureTemplatesTypes, TemplateInfo
 from catalystwan.endpoints.configuration_device_template import FeatureToCLIPayload
-from catalystwan.exceptions import AttachedError, TemplateNotFoundError
+from catalystwan.exceptions import AttachedError, InvalidOperationError, TemplateNotFoundError
 from catalystwan.response import ManagerResponse
 from catalystwan.typed_list import DataSequence
 from catalystwan.utils.device_model import DeviceModel
@@ -122,8 +122,15 @@ class TemplatesAPI:
         templates = self.session.get(url=endpoint, params=params)
         return templates.dataseq(DeviceTemplateInfo)
 
-    def attach(self, name: str, device: Device, timeout_seconds: int = 300, **kwargs):
-        template_type = self.get(DeviceTemplate).filter(name=name).single_or_default().config_type
+    def attach(self, name: str, device: Optional[Device], timeout_seconds: int = 300, **kwargs):
+        template_info = self.get(DeviceTemplate).filter(name=name).single_or_default()
+        if template_info is None:
+            raise TemplateNotFoundError(name)
+
+        if device is None:
+            raise InvalidOperationError(f"Device is required to attach template '{name}'.")
+
+        template_type = template_info.config_type
         if template_type == TemplateType.CLI:
             return self._attach_cli(name, device, timeout_seconds=timeout_seconds, **kwargs)
 
@@ -156,6 +163,7 @@ class TemplatesAPI:
             values = self.session.post(endpoint, json=body).json()["header"]["columns"]
             return [DeviceSpecificValue(**value) for value in values]
 
+        device_specific_vars = kwargs.get("device_specific_vars", {})
         vars = get_device_specific_variables(name)
         template_id = self.get(DeviceTemplate).filter(name=name).single_or_default().id
         payload = {
@@ -179,11 +187,11 @@ class TemplatesAPI:
         for var in vars:
             if var.property not in payload["deviceTemplateList"][0]["device"][0]:
                 pointer = payload["deviceTemplateList"][0]["device"][0]
-                if var.property not in kwargs["device_specific_vars"]:
+                if var.property not in device_specific_vars:
                     invalid = True
                     logger.error(f"{var.property} should be provided in attach method as device_specific_vars kwarg.")
                 else:
-                    pointer[var.property] = kwargs["device_specific_vars"][var.property]  # type: ignore
+                    pointer[var.property] = device_specific_vars[var.property]  # type: ignore
 
         if invalid:
             raise TypeError()

--- a/catalystwan/endpoints/configuration_device_inventory.py
+++ b/catalystwan/endpoints/configuration_device_inventory.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from catalystwan.endpoints import APIEndpoints, CustomPayloadType, PreparedPayload, delete, get, post, versions
 from catalystwan.typed_list import DataSequence
@@ -63,6 +63,7 @@ class DeviceDetailsResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True, protected_namespaces=())
 
     device_type: Optional[str] = Field(default=None, validation_alias="deviceType", serialization_alias="deviceType")
+    device_id: Optional[str] = Field(default=None, validation_alias="deviceId", serialization_alias="deviceId")
     serial_number: Optional[str] = Field(
         default=None, validation_alias="serialNumber", serialization_alias="serialNumber"
     )
@@ -76,7 +77,9 @@ class DeviceDetailsResponse(BaseModel):
     config_operation_mode: Optional[str] = Field(
         default=None, validation_alias="configOperationMode", serialization_alias="configOperationMode"
     )
-    device_model: Optional[str] = Field(default=None, validation_alias="deviceModel", serialization_alias="deviceModel")
+    device_model: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("deviceModel", "device-model"), serialization_alias="deviceModel"
+    )
     device_state: Optional[str] = Field(default=None, validation_alias="deviceState", serialization_alias="deviceState")
     validity: Optional[str] = None
     platform_family: Optional[str] = Field(
@@ -169,12 +172,20 @@ class DeviceDetailsResponse(BaseModel):
     )
     domain_id: Optional[str] = Field(default=None, validation_alias="domain-id", serialization_alias="domain-id")
     local_system_ip: Optional[str] = Field(
-        default=None, validation_alias="local-system-ip", serialization_alias="ocal-system-ip"
+        default=None,
+        validation_alias=AliasChoices("local-system-ip", "localSystemIp", "localSystemIP"),
+        serialization_alias="local-system-ip",
     )
-    system_ip: Optional[str] = Field(default=None, validation_alias="system-ip", serialization_alias="system-ip")
+    system_ip: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("system-ip", "systemIp", "systemIP"),
+        serialization_alias="system-ip",
+    )
     model_sku: Optional[str] = Field(default=None)
     site_id: Optional[str] = Field(default=None, validation_alias="site-id", serialization_alias="site-id")
-    host_name: Optional[str] = Field(default=None, validation_alias="host-name", serialization_alias="host-name")
+    host_name: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("host-name", "hostName"), serialization_alias="host-name"
+    )
     sp_organization_name: Optional[str] = Field(
         default=None, validation_alias="sp-organization-name", serialization_alias="sp-organization-name"
     )

--- a/catalystwan/tests/test_devices_api.py
+++ b/catalystwan/tests/test_devices_api.py
@@ -9,6 +9,7 @@ from tenacity import RetryError  # type: ignore
 
 from catalystwan.api.basic_api import DevicesAPI, DeviceStateAPI
 from catalystwan.dataclasses import BfdSessionData, Connection, Device, WanInterface
+from catalystwan.endpoints.configuration_device_inventory import DeviceDetailsResponse
 from catalystwan.endpoints.endpoints_container import APIEndpointContainter
 from catalystwan.endpoints.monitoring.device_details import DeviceData
 from catalystwan.endpoints.real_time_monitoring.reboot_history import RebootEntry
@@ -17,6 +18,7 @@ from catalystwan.response import ManagerResponse
 from catalystwan.typed_list import DataSequence
 from catalystwan.utils.creation_tools import create_dataclass
 from catalystwan.utils.personality import Personality
+from catalystwan.utils.reachability import Reachability
 
 
 class ResponseMock:
@@ -118,6 +120,32 @@ class TestDevicesAPI(TestCase):
         self.system_ips_list = [device["local-system-ip"] for device in self.devices]
         self.ips_list = [device["deviceId"] for device in self.devices]
         self.list_all_devices_resp = DataSequence(DeviceData, [DeviceData.model_validate(dev) for dev in self.devices])
+        self.inventory_edge = DeviceDetailsResponse.model_validate(
+            {
+                "uuid": "dddddddd-6169-445c-8e49-c0bdaaaaaaa",
+                "deviceIP": "169.254.10.81",
+                "host-name": "vm81",
+                "personality": "vedge",
+                "local-system-ip": "169.254.10.81",
+                "deviceModel": "vedge-C8000V",
+                "site-id": "81",
+                "deviceState": "valid",
+            }
+        )
+        self.inventory_edge_dataclass = create_dataclass(
+            Device,
+            {
+                "uuid": "dddddddd-6169-445c-8e49-c0bdaaaaaaa",
+                "personality": Personality.EDGE,
+                "id": "169.254.10.81",
+                "hostname": "vm81",
+                "reachability": Reachability.UNKNOWN,
+                "local_system_ip": "169.254.10.81",
+                "status": "valid",
+                "model": "vedge-C8000V",
+                "site_id": "81",
+            },
+        )
 
     @patch("catalystwan.response.ManagerResponse")
     @patch("catalystwan.session.ManagerSession")
@@ -198,6 +226,28 @@ class TestDevicesAPI(TestCase):
 
         # Assert
         self.assertEqual(answer, self.devices_dataseq)
+
+    @patch("catalystwan.response.ManagerResponse")
+    @patch("catalystwan.session.ManagerSession")
+    def test_get_includes_unmonitored_wan_edge_inventory(self, mock_session, mock_response):
+        # Arrange
+        mock_session.get.return_value = mock_response
+        mock_session.endpoints.monitoring_device_details.list_all_devices.return_value = DataSequence(
+            DeviceData, [DeviceData.model_validate(self.devices[0])]
+        )
+        mock_session.endpoints.configuration_device_inventory.get_device_details.return_value = DataSequence(
+            DeviceDetailsResponse, [self.inventory_edge]
+        )
+        mock_response.dataseq.return_value = DataSequence(Device, [create_dataclass(Device, self.devices[0])])
+
+        # Act
+        answer = DevicesAPI(mock_session).get()
+
+        # Assert
+        self.assertEqual(
+            answer,
+            DataSequence(Device, [create_dataclass(Device, self.devices[0]), self.inventory_edge_dataclass]),
+        )
 
     @parameterized.expand(
         [

--- a/catalystwan/tests/test_templates.py
+++ b/catalystwan/tests/test_templates.py
@@ -12,7 +12,8 @@ from catalystwan.api.templates.device_template.device_template import DeviceTemp
 from catalystwan.api.templates.feature_template import FeatureTemplate
 from catalystwan.api.templates.models.cisco_aaa_model import CiscoAAAModel
 from catalystwan.api.templates.payloads.aaa.aaa_model import AAAModel, AuthenticationOrder
-from catalystwan.dataclasses import Device, FeatureTemplateInfo, TemplateInfo
+from catalystwan.dataclasses import Device, DeviceTemplateInfo, FeatureTemplateInfo, TemplateInfo
+from catalystwan.exceptions import InvalidOperationError, TemplateNotFoundError
 from catalystwan.typed_list import DataSequence
 from catalystwan.utils.creation_tools import create_dataclass
 from catalystwan.utils.device_model import DeviceModel
@@ -260,6 +261,29 @@ class TestTemplatesAPI(unittest.TestCase):
         assert not mock_create_device_template.called
         assert not mock_create_feature_template.called
         assert not mock_create_by_generator.called
+
+    @patch("catalystwan.session.ManagerSession")
+    def test_attach_missing_template_raises_template_not_found(self, mock_session):
+        # Arrange
+        mock_session.get.return_value.dataseq.return_value = DataSequence(DeviceTemplateInfo, [])
+        templates_api = TemplatesAPI(mock_session)
+
+        # Act / Assert
+        with self.assertRaises(TemplateNotFoundError):
+            templates_api.attach("missing_template", self.device_info)
+
+    @patch("catalystwan.session.ManagerSession")
+    def test_attach_missing_device_raises_invalid_operation(self, mock_session):
+        # Arrange
+        mock_session.get.return_value.dataseq.return_value = DataSequence(
+            DeviceTemplateInfo,
+            [create_dataclass(DeviceTemplateInfo, self.data_template[0])],
+        )
+        templates_api = TemplatesAPI(mock_session)
+
+        # Act / Assert
+        with self.assertRaises(InvalidOperationError):
+            templates_api.attach("template_1", None)
 
     # @patch.object(TemplatesAPI, "templates")
     # @patch("catalystwan.api.template_api.wait_for_completed")


### PR DESCRIPTION
## Summary

Fix `DevicesAPI.get()` so callers can resolve WAN edge devices that are present in configuration inventory but absent from the monitored `/dataservice/device` response on newer vManage trains.

This is the replacement for #197 with the CI-only commits removed, per the maintainer comment on #197 after #198 merged the CI fixes into `main`.

## Root Cause

In the failing vTest run, `mtt_aaa.test_create_attach_device_template` looked up `vm81` with `DevicesAPI(provider_session).get().filter(hostname=mt_edge.name).single_or_default()`. On vManage `27.1.991-1`, `/dataservice/device` returned only controllers before template attach, so the lookup returned `None`. `TemplatesAPI.attach()` then dereferenced `device.uuid`, producing a raw `AttributeError`.

## Changes

- Preserve the existing monitored-device flow through `/dataservice/device` and `/dataservice/device/system/info`.
- Add a best-effort fallback that merges missing WAN edges from configuration device inventory (`vedges`).
- Broaden `DeviceDetailsResponse` aliases for newer/older inventory payload field names.
- Raise explicit SDK errors when `TemplatesAPI.attach()` is called with a missing template or device.
- Add unit tests for inventory-backed device discovery and template attach error handling.

## Validation

- `uv run pytest catalystwan/tests/test_devices_api.py catalystwan/tests/test_templates.py` -> `55 passed, 1 skipped`
- `uv run flake8 catalystwan/api/basic_api.py catalystwan/api/template_api.py catalystwan/endpoints/configuration_device_inventory.py catalystwan/tests/test_devices_api.py catalystwan/tests/test_templates.py`
- `uv run mypy --show-error-codes --show-error-context --pretty --install-types --non-interactive catalystwan --cache-dir=.mypy_cache/ --disable-error-code override`
- `git diff --check origin/main...HEAD`
