### PR TITLE
[dev]: ethernet speed and vrrp tloc pref change value

### DIFF
--- a/catalystwan/models/common.py
+++ b/catalystwan/models/common.py
@@ -994,7 +994,7 @@ MediaType = Literal[
     "sfp",
 ]
 
-Speed = Literal["10", "100", "1000", "2500", "5000", "10000", "25000"]
+Speed = Literal["10", "100", "1000", "2500", "5000", "10000", "25000", "40000", "100000"]
 
 EthernetNatType = Literal["pool", "loopback", "interface"]
 

--- a/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
@@ -251,7 +251,7 @@ class VrrpIPv4(BaseModel):
     tloc_pref_change: Union[Global[bool], Default[bool]] = Field(
         serialization_alias="tlocPrefChange", validation_alias="tlocPrefChange", default=Default[bool](value=False)
     )
-    tloc_pref_change_value: Optional[Union[Global[int], Default[None]]] = Field(
+    tloc_pref_change_value: Optional[Union[Global[int], Variable, Default[None]]] = Field(
         serialization_alias="tlocPrefChangeValue", validation_alias="tlocPrefChangeValue", default=None
     )
     tracking_object: Optional[List[VrrpTrackingObject]] = Field(

--- a/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
@@ -15,7 +15,7 @@ from pydantic import (
 from typing_extensions import Annotated
 
 from catalystwan.api.configuration_groups.parcel import Default, Global, Variable, _ParcelBase
-from catalystwan.models.common import EthernetDuplexMode, MediaType, VersionedField
+from catalystwan.models.common import EthernetDuplexMode, MediaType, Speed, VersionedField
 from catalystwan.models.configuration.feature_profile.common import (
     AddressType,
     Arp,
@@ -318,7 +318,7 @@ class AdvancedEthernetAttributes(BaseModel):
     tcp_mss: Optional[Union[Global[int], Variable, Default[int]]] = Field(
         serialization_alias="tcpMss", validation_alias="tcpMss", default=None
     )
-    speed: Optional[Union[Global[str], Variable, Default[None]]] = None
+    speed: Optional[Union[Global[Speed], Variable, Default[None]]] = None
     arp_timeout: Union[Global[int], Variable, Default[int]] = Field(
         serialization_alias="arpTimeout", validation_alias="arpTimeout", default=Default[int](value=1200)
     )

--- a/catalystwan/models/configuration/feature_profile/sdwan/transport/management/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/transport/management/ethernet.py
@@ -5,7 +5,7 @@ from typing import List, Literal, Optional, Union
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
 
 from catalystwan.api.configuration_groups.parcel import Default, Global, Variable, _ParcelBase
-from catalystwan.models.common import EthernetDuplexMode, MediaType, Speed
+from catalystwan.models.common import EthernetDuplexMode, MediaType
 from catalystwan.models.configuration.feature_profile.common import (
     AddressType,
     Arp,
@@ -13,6 +13,8 @@ from catalystwan.models.configuration.feature_profile.common import (
     InterfaceEitherIPv4Address,
     InterfaceStaticIPv4Address,
 )
+
+Speed = Literal["10", "100", "1000", "2500", "5000", "10000", "25000"]
 
 
 class DhcpClient(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.41.5dev5"
+version = "0.41.5dev6"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["sbasan <sbasan@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
Added new values to the ethernet speed and tloc pref change value

# Description of changes:
- lan/wan ethernet speed could accept values: "40000" and "100000" starting from vManage 26.1
- management ethernet speed have different validation, without new values, so it must use different Speed literal
- tlocPrefChangeValue in lan ethernet could accept Variable

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
