### PR TITLE
[dev]: IPoEEthernet intf ip address

### DIFF
--- a/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/protocol_over.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/transport/wan/interface/protocol_over.py
@@ -12,8 +12,8 @@ from catalystwan.api.configuration_groups.parcel import Default, Global, Variabl
 from catalystwan.models.common import CarrierType, TLOCColor, TunnelMode
 from catalystwan.models.configuration.feature_profile.common import (
     AclQos,
-    AddressWithMask,
     AllowService,
+    InterfaceStaticIPv4Address,
     MultiRegionFabric,
 )
 
@@ -290,25 +290,8 @@ class Dynamic(BaseModel):
     )
 
 
-class Static(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-        populate_by_name=True,
-    )
-    static_ip_v4: Optional[AddressWithMask] = Field(
-        default=None,
-        validation_alias="staticIpV4AddressPrimary",
-        serialization_alias="staticIpV4AddressPrimary",
-        description="Static IpV4Address Primary",
-    )
-
-
 class DynamicIntfIpAddress(BaseModel):
     dynamic: Dynamic = Field()
-
-
-class StaticIntfIpAddress(BaseModel):
-    static: Static = Field()
 
 
 class IPoEEthernet(Ethernet):
@@ -316,7 +299,7 @@ class IPoEEthernet(Ethernet):
         extra="forbid",
         populate_by_name=True,
     )
-    intf_ip_address: Union[DynamicIntfIpAddress, StaticIntfIpAddress] = Field(
+    intf_ip_address: Union[DynamicIntfIpAddress, InterfaceStaticIPv4Address] = Field(
         validation_alias="intfIpAddress", serialization_alias="intfIpAddress"
     )
 


### PR DESCRIPTION
# Pull Request summary:
Changed IPoEEthernet intf ip address to use common static ipv4

# Description of changes:
The previously used `StaticIntfIpAddress` in the `IPoEEthernet`  was in wrong format. 
`AddressWithMask` has fields `address` and `mask` where for the `IPoEEthernet` it should be `ipAddress` and `subnetMask`. Those fields are in the `StaticIPv4Address` common model.

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
