### PR TITLE
Normalize OMP peer values across SD-WAN versions

### DIFF
--- a/catalystwan/dataclasses.py
+++ b/catalystwan/dataclasses.py
@@ -178,10 +178,15 @@ class BfdSessionData(DataclassBase):
     destinationPublicIp: str = field(metadata={FIELD_NAME: "dst-ip"})
 
 
+def _remove_omp_peer_prefix(value: str, prefix: str) -> str:
+    """Normalize OMP peer enum values returned by different SD-WAN versions."""
+    return value[len(prefix) :] if value.startswith(prefix) else value
+
+
 @define
 class OmpPeerData(DataclassBase):
-    type: str
-    state: str
+    type: str = field(converter=lambda value: _remove_omp_peer_prefix(value, "device-"))
+    state: str = field(converter=lambda value: _remove_omp_peer_prefix(value, "peer-state-"))
     peerIp: str = field(metadata={FIELD_NAME: "peer"})
     siteId: str = field(metadata={FIELD_NAME: "site-id"})
     domainId: str = field(metadata={FIELD_NAME: "domain-id"})

--- a/catalystwan/tests/test_omp_api.py
+++ b/catalystwan/tests/test_omp_api.py
@@ -25,6 +25,31 @@ class TestOmpAPI(unittest.TestCase):
         answer = OmpAPI(mock_session).get_omp_peers(self.device_id)
         # Assert
         self.assertEqual(answer, self.omp_peer_dataclass)
+        self.assertEqual(answer[0].type, "vsmart")
+        self.assertEqual(answer[0].state, "up")
+
+    @patch("catalystwan.session.Session")
+    def test_omp_peers_normalizes_prefixed_values(self, mock_session):
+        # Arrange
+        mock_session.get_data.return_value = [
+            {
+                **self.omp_peer[0],
+                "type": "device-vsmart",
+                "state": "peer-state-up",
+            },
+            {
+                **self.omp_peer[1],
+                "type": "device-vsmart",
+                "state": "peer-state-down",
+            },
+        ]
+        # Act
+        answer = OmpAPI(mock_session).get_omp_peers(self.device_id)
+        # Assert
+        self.assertEqual(answer[0].type, "vsmart")
+        self.assertEqual(answer[0].state, "up")
+        self.assertEqual(answer[1].type, "vsmart")
+        self.assertEqual(answer[1].state, "down")
 
     @patch("catalystwan.session.Session")
     def test_omp_peers_empty(self, mock_session):


### PR DESCRIPTION
## Pull Request summary

Keep `OmpPeerData.type` and `OmpPeerData.state` backward compatible when newer SD-WAN releases return prefixed values.

## Description of changes

- Strip `peer-state-` from OMP peer state values (for example, `peer-state-up` becomes `up`).
- Strip `device-` from OMP peer type values (for example, `device-vsmart` becomes `vsmart`).
- Preserve legacy unprefixed values unchanged.
- Add regression coverage for both payload formats.

## Example

A newer SD-WAN release can return this payload:

```json
{
  "type": "device-vsmart",
  "state": "peer-state-up"
}
```

The SDK normalizes it to the same values exposed for older releases:

```python
peer.type == "vsmart"
peer.state == "up"
```

A legacy payload containing `"type": "vsmart"` and `"state": "up"` remains unchanged.

## Testing

- `python -m compileall catalystwan`
- Added unit coverage for legacy, prefixed-up, and prefixed-down values.
- All repository CI checks passed.