### PR TITLE
[dev] sig shutdown variable and ipsec ciphersuite literal

### DIFF
--- a/catalystwan/models/configuration/feature_profile/sdwan/sig_security/sig_security.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/sig_security/sig_security.py
@@ -16,7 +16,15 @@ TunnelDcPreference = Literal["primary-dc", "secondary-dc"]
 IkeGroup = Literal["2", "5", "14", "15", "16", "19", "20", "21"]
 IpsecReplayWindow = Literal[64, 128, 256, 512, 1024]
 IpsecCiphersuite = Literal[
-    "aes256-cbc-sha1", "aes256-cbc-sha384", "aes256-cbc-sha256", "aes256-cbc-sha512", "aes256-gcm"
+    "aes256-cbc-sha1",
+    "aes256-cbc-sha384",
+    "aes256-cbc-sha256",
+    "aes256-cbc-sha512",
+    "aes256-gcm",
+    "null-sha1",
+    "null-sha384",
+    "null-sha256",
+    "null-sha512",
 ]
 PerfectForwardSecrecy = Literal[
     "group-2", "group-5", "group-14", "group-15", "group-16", "group-19", "group-20", "group-21", "none"
@@ -41,7 +49,9 @@ class Interface(BaseModel):
         serialization_alias="ifName", validation_alias="ifName", description="Interface name: IPsec when present"
     )
     auto: Optional[Global[bool]] = Field(default=None, description="Auto Tunnel Mode")
-    shutdown: Union[Global[bool], Default[bool]] = Field(default=as_default(False), description="Administrative state")
+    shutdown: Union[Global[bool], Default[bool], Variable] = Field(
+        default=as_default(False), description="Administrative state"
+    )
     description: Optional[Union[Global[str], Variable, Default[None]]] = Field(
         default=None, description="Interface description"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.41.6dev0"
+version = "0.41.6dev1"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["sbasan <sbasan@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
Added missing entries for the `IpsecCiphersuite` literal. They were removed in later versions, but they're still required in the vManage 20.12.
Added Variable option for shutdown, introduced in the vManage 26.1

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
