### PR TITLE
[dev]: globalOtherSettingsIntfPerMin

### DIFF
--- a/catalystwan/models/configuration/feature_profile/sdwan/system/global_parcel.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/system/global_parcel.py
@@ -17,6 +17,7 @@ EtherchannelFlowLoadBalance = Literal[
     "src-ip",
     "src-mac",
 ]
+InterfaceIntervalOptions = Literal["1", "5"]
 
 
 class ServicesIp(BaseModel):
@@ -109,7 +110,7 @@ class ServicesIp(BaseModel):
         serialization_alias="globalOtherSettingsVtyLineLogging",
         validation_alias="globalOtherSettingsVtyLineLogging",
     )
-    snmp_ifindex_persist: (Union[Variable, Global[bool], Default[bool]]) = Field(
+    snmp_ifindex_persist: Union[Variable, Global[bool], Default[bool]] = Field(
         default=Default[bool](value=True),
         serialization_alias="globalOtherSettingsSnmpIfindexPersist",
         validation_alias="globalOtherSettingsSnmpIfindexPersist",
@@ -141,6 +142,13 @@ class ServicesIp(BaseModel):
     )
     lacp_system_priority: Optional[Union[Variable, Global[int], Default[None]]] = Field(
         default=None, validation_alias="lacpSystemPriority", serialization_alias="lacpSystemPriority"
+    )
+    intf_per_min: Optional[Union[Variable, Global[InterfaceIntervalOptions], Default[InterfaceIntervalOptions]]] = (
+        Field(
+            default=None,
+            serialization_alias="globalOtherSettingsIntfPerMin",
+            validation_alias="globalOtherSettingsIntfPerMin",
+        )
     )
 
 


### PR DESCRIPTION
# Pull Request summary:
Add globalOtherSettingsIntfPerMin to configure interface statistics per minute in global parcel. That option was added in vManage 26.1.

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
